### PR TITLE
Enable to connect to remote host

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+    "name": "biochatter Dev Container",
+    "image": "mcr.microsoft.com/vscode/devcontainers/python:3.10",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+    // Environment variables (secrets) to pass into the devcontainer.
+    "runArgs": [
+        // "--env-file", // Online mode (REDIS and community key)
+        // ".devcontainer/online.env",
+        "--env-file", // Offline mode (only API key)
+        ".devcontainer/local.env",
+        "--network=milvus" // Comment out if not using docker-compose, else will lead to error
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            "settings": {},
+            "extensions": [
+                "GitHub.copilot-chat",
+                "GitHub.copilot-nightly",
+                "ms-azuretools.vscode-docker",
+                "ms-python.black-formatter"
+            ]
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [9000],
+    // Use 'portsAttributes' to set default properties for specific forwarded ports. 
+    // More info: https://containers.dev/implementors/json_reference/#port-attributes
+    // "portsAttributes": {
+    //     "9000": {
+    //         "label": "Hello Remote World",
+    //         "onAutoForward": "notify"
+    //     }
+    // },
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    "remoteUser": "root",
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "bash ./.devcontainer/post-install.sh"
+}

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -ex
+
+##
+## Create some aliases
+##
+echo 'alias ll="ls -alF"' >> $HOME/.bashrc
+echo 'alias la="ls -A"' >> $HOME/.bashrc
+echo 'alias l="ls -CF"' >> $HOME/.bashrc
+
+# Convenience workspace directory for later use
+WORKSPACE_DIR=$(pwd)
+
+# Change some Poetry settings to better deal with working in a container
+pip install poetry==1.2.2
+poetry config cache-dir ${WORKSPACE_DIR}/.cache
+poetry config virtualenvs.create false
+
+# Now install all dependencies
+poetry install -E "streamlit podcast"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 .pytest_cache
 .env
 *.mp3
+.cache
+*.env

--- a/README.md
+++ b/README.md
@@ -27,3 +27,17 @@ on your machine. Then, you can run the devcontainer setup as recommended by
 VSCode
 [here](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)
 or using Docker directly.
+
+The dev container expects an environment file (there are options, but the basic
+one is `.devcontainer/local.env`) with the following variables:
+
+```
+OPENAI_API_KEY=(sk-...)
+DOCKER_COMPOSE=true
+DEVCONTAINER=true
+```
+
+To test vector database functionality, you also need to start a Milvus
+standalone server. You can do this by running `docker-compose up` as described
+[here](https://milvus.io/docs/install_standalone-docker.md) on the host machine
+(not from inside the devcontainer).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # biochatter
-This repository contains the `biochatter` Python package, a generic backend library for the connection of biomedical applications to conversational AI. Described in [this preprint](https://arxiv.org/abs/2305.06488) and used in [ChatGSE](https://chat.biocypher.org), which is being developed at https://github.com/biocypher/ChatGSE. More to come, so stay tuned!
+
+This repository contains the `biochatter` Python package, a generic backend
+library for the connection of biomedical applications to conversational AI.
+Described in [this preprint](https://arxiv.org/abs/2305.06488) and used in
+[ChatGSE](https://chat.biocypher.org), which is being developed at
+https://github.com/biocypher/ChatGSE. More to come, so stay tuned!
 
 ## Installation
-To use the package, install it from PyPI, for instance using pip (`pip install biochatter`) or Poetry (`poetry add biochatter`).
+
+To use the package, install it from PyPI, for instance using pip (`pip install
+biochatter`) or Poetry (`poetry add biochatter`).
+
+### Extras
+
+The package has some optional dependencies that can be installed using the
+following extras (e.g. `pip install biochatter[streamlit]`):
+
+- `streamlit`: support for streamlit UI functions (used in ChatGSE)
+- `podcast`: support for podcast text-to-speech
+
+# Dev Container
+
+Due to some incompatibilities of `pymilvus` with Apple Silicon, we have created
+a dev container for this project. To use it, you need to have Docker installed
+on your machine. Then, you can run the devcontainer setup as recommended by
+VSCode
+[here](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)
+or using Docker directly.

--- a/biochatter/llm_connect.py
+++ b/biochatter/llm_connect.py
@@ -152,12 +152,12 @@ class Conversation(ABC):
                 msg = self.prompts["tool_prompts"][tool_name].format(df=df)
                 self.append_system_message(msg)
 
-    def query(self, text: str):
+    def query(self, text: str, collection_name: Optional[str]=None):
         self.append_user_message(text)
 
         if self.docsum:
             if self.docsum.use_prompt:
-                self._inject_context(text)
+                self._inject_context(text, collection_name)
 
         msg, token_usage = self._primary_query()
 
@@ -213,7 +213,7 @@ class Conversation(ABC):
     def _correct_response(self, msg: str):
         pass
 
-    def _inject_context(self, text: str):
+    def _inject_context(self, text: str, collection_name: Optional[str]=None):
         """
         Inject the context into the prompt from vector database similarity
         search. Finds the most similar n text fragments and adds them to the
@@ -244,6 +244,7 @@ class Conversation(ABC):
                     for doc in self.docsum.similarity_search(
                         text,
                         self.docsum.n_results,
+                        collection_name
                     )
                 ]
         else:
@@ -252,6 +253,7 @@ class Conversation(ABC):
                 for doc in self.docsum.similarity_search(
                     text,
                     self.docsum.n_results,
+                    collection_name
                 )
             ]
 

--- a/biochatter/llm_connect.py
+++ b/biochatter/llm_connect.py
@@ -152,7 +152,7 @@ class Conversation(ABC):
                 msg = self.prompts["tool_prompts"][tool_name].format(df=df)
                 self.append_system_message(msg)
 
-    def query(self, text: str, collection_name: Optional[str]=None):
+    def query(self, text: str, collection_name: Optional[str] = None):
         self.append_user_message(text)
 
         if self.docsum:
@@ -213,7 +213,7 @@ class Conversation(ABC):
     def _correct_response(self, msg: str):
         pass
 
-    def _inject_context(self, text: str, collection_name: Optional[str]=None):
+    def _inject_context(self, text: str, collection_name: Optional[str] = None):
         """
         Inject the context into the prompt from vector database similarity
         search. Finds the most similar n text fragments and adds them to the
@@ -244,7 +244,7 @@ class Conversation(ABC):
                     for doc in self.docsum.similarity_search(
                         text,
                         self.docsum.n_results,
-                        collection_name
+                        collection_name,
                     )
                 ]
         else:
@@ -253,7 +253,7 @@ class Conversation(ABC):
                 for doc in self.docsum.similarity_search(
                     text,
                     self.docsum.n_results,
-                    collection_name
+                    collection_name,
                 )
             ]
 

--- a/biochatter/vectorstore.py
+++ b/biochatter/vectorstore.py
@@ -73,10 +73,6 @@ class DocumentEmbedder:
     def set_document(self, document: List[Document]) -> None:
         self.document = document
 
-    def _load_document(self, path: str) -> None:
-        reader = DocumentReader()
-        self.document = reader.load_document(path)
-
     def _characters_splitter(self) -> RecursiveCharacterTextSplitter:
         return RecursiveCharacterTextSplitter(
             chunk_size=self.chunk_size,

--- a/biochatter/vectorstore.py
+++ b/biochatter/vectorstore.py
@@ -57,15 +57,15 @@ class DocumentEmbedder:
             "host": "127.0.0.1",
             "port": "19530",
         }
+        self.document = None
+        
         # TODO: vector db selection
         self.vector_db_vendor = vector_db_vendor or "milvus"
-        
-        self.document = None
 
         # instantiate VectorDatabaseHost
         self.database_host = None
         self._init_database_host()
-        # Todo: remove temporary attribute current_collection_name
+        # TODO: remove temporary attribute current_collection_name
         # The current collection name is intended to be saved and passed from front-end when calling similarity_search()
         # and drop_collection(). However, to avoid breaking existing ChatGSE code, we introduce it temporarily. Once 
         # ChatGSE is updated to store and pass current collection name with each request, we can remove this temporary
@@ -75,7 +75,6 @@ class DocumentEmbedder:
     def _init_database_host(self):
         if self.vector_db_vendor == "milvus":
             self.database_host = VectorDatabaseHostMilvus(embeddings=self.embeddings, connection_args=self.connection_args)
-            self.connect(self.connection_args["host"], self.connection_args["port"])
         else:
             raise NotImplementedError(self.vector_db_vendor)
         
@@ -135,6 +134,8 @@ class DocumentEmbedder:
             query (str): query string
 
             k (int, optional): number of closest matches to return. Defaults to 3.
+
+            collection_name (str): search in collection {collection_name}
 
         """
         collection_name = collection_name or self.current_collection_name

--- a/biochatter/vectorstore.py
+++ b/biochatter/vectorstore.py
@@ -4,7 +4,7 @@
 # do similarity search
 # return x closes matches for in-context learning
 
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from langchain.schema import Document
 from langchain.embeddings.openai import OpenAIEmbeddings
@@ -14,6 +14,8 @@ from langchain.vectorstores import Milvus
 
 import fitz  # this is PyMuPDF (PyPI pymupdf package, not fitz)
 from transformers import GPT2TokenizerFast
+
+from biochatter.vectorstore_host import VectorDatabaseHostMilvus
 
 class DocumentEmbedder:
     def __init__(
@@ -57,10 +59,24 @@ class DocumentEmbedder:
         }
         # TODO: vector db selection
         self.vector_db_vendor = vector_db_vendor or "milvus"
-        self.vector_db = None
-
+        
         self.document = None
 
+        # instantiate VectorDatabaseHost
+        self.database_host = None
+        self._init_database_host()
+        # Todo: Current collection name is supposed to be saved in front-end, but to be compatible, we introduce
+        # it temporarily. Once ChatGSE implements the function of current collection name (saving current collection and 
+        # passing it to call similarity_search() or drop_collection()), we will remove this attribute.
+        self.current_collection_name = None
+
+    def _init_database_host(self):
+        if self.vector_db_vendor == "milvus":
+            self.database_host = VectorDatabaseHostMilvus(embeddings=self.embeddings, connection_args=self.connection_args)
+            self.connect(self.connection_args["host"], self.connection_args["port"])
+        else:
+            raise NotImplementedError(self.vector_db_vendor)
+        
     def set_chunk_siue(self, chunk_size: int) -> None:
         self.chunk_size = chunk_size
 
@@ -104,35 +120,36 @@ class DocumentEmbedder:
         text_splitter = self._text_splitter()
         self.split = text_splitter.split_documents(self.document)
 
-    def store_embeddings(self) -> None:
-        if self.vector_db_vendor == "milvus":
-            self.vector_db = Milvus.from_documents(
-                documents=self.split,
-                embedding=self.embeddings,
-                connection_args=self.connection_args,
-            )
-        else:
-            raise NotImplementedError(self.vector_db_vendor)
+    def store_embeddings(self, doc_name: Optional[str]="document") -> Dict[str, str]:
+        vector_collection = self.database_host.store_embedding(doc_name=doc_name, documents=self.split)
+        self.current_collection_name = vector_collection["collection_name"]
+        return vector_collection
 
-    def similarity_search(self, query: str, k: int = 3):
+    def similarity_search(self, query: str, k: int = 3, collection_name: Optional[str]=None):
         """
         Returns top n closest matches to query from vector store.
 
         Args:
             query (str): query string
 
-            k (int, optional): number of closest matches to return. Defaults to
-            3.
+            k (int, optional): number of closest matches to return. Defaults to 3.
 
         """
-        if self.vector_db_vendor == "milvus":
-            if not self.vector_db:
-                raise ValueError("No vector store loaded")
-            return self.vector_db.similarity_search(
-                query=query, k=k or self.n_results
-            )
-        else:
-            raise NotImplementedError(self.vector_db_vendor)
+        collection_name = collection_name or self.current_collection_name
+        return self.database_host.similarity_search(
+            collection_name=collection_name, 
+            query=query, 
+            k=k or self.n_results
+        )
+    
+    def connect(self, host: str, port: str) -> None:
+        self.database_host.connect(host, port)
+
+    def get_all_collections(self) -> List[Dict[str, str]]:
+        return self.database_host.collections
+        
+    def drop_collection(self, collection_name: str) -> None:
+        self.database_host.drop_collection(collection_name)
 
 
 class DocumentReader:

--- a/biochatter/vectorstore.py
+++ b/biochatter/vectorstore.py
@@ -65,9 +65,11 @@ class DocumentEmbedder:
         # instantiate VectorDatabaseHost
         self.database_host = None
         self._init_database_host()
-        # Todo: Current collection name is supposed to be saved in front-end, but to be compatible, we introduce
-        # it temporarily. Once ChatGSE implements the function of current collection name (saving current collection and 
-        # passing it to call similarity_search() or drop_collection()), we will remove this attribute.
+        # Todo: remove temporary attribute current_collection_name
+        # The current collection name is intended to be saved and passed from front-end when calling similarity_search()
+        # and drop_collection(). However, to avoid breaking existing ChatGSE code, we introduce it temporarily. Once 
+        # ChatGSE is updated to store and pass current collection name with each request, we can remove this temporary
+        # current_collection_name attribute.
         self.current_collection_name = None
 
     def _init_database_host(self):

--- a/biochatter/vectorstore_host.py
+++ b/biochatter/vectorstore_host.py
@@ -2,12 +2,19 @@ import logging
 from typing import List, Optional, Tuple, Dict
 import re
 import base64
-from pymilvus import MilvusException, connections, Collection, utility, FieldSchema
+from pymilvus import (
+    MilvusException,
+    connections,
+    Collection,
+    utility,
+    FieldSchema,
+)
 from langchain.vectorstores import Milvus
 from langchain.embeddings import OpenAIEmbeddings
 from langchain.schema import Document
 
 logger = logging.getLogger(__name__)
+
 
 def _grab_text_field_name(fields: List[FieldSchema]) -> str | None:
     prev_field = None
@@ -17,31 +24,36 @@ def _grab_text_field_name(fields: List[FieldSchema]) -> str | None:
         prev_field = x
     return None
 
+
 def extract_from_alias(alias: str) -> Optional[Tuple]:
     # valid alias is {base64}_c{uuid4.hex}
     pattern = r"^([0-9a-zA-Z_]+)_c([a-f0-9]{32})$"
     match = re.fullmatch(pattern, alias)
     return None if not match else match.groups()
 
+
 def string_to_base64(txt: str) -> str:
-    '''
+    """
     As collection alias only supports numbers, letters and underscores, we have
     to encode document name to url base64 string, and encode "-" and "=" of base64
     string to "a_a" and "b_b"
-    '''
+    """
     try:
-        converted = base64.urlsafe_b64encode(txt.encode("utf-8")).decode("utf-8")
-        return converted.replace('-', 'a_a').replace("=", "b_b")
+        converted = base64.urlsafe_b64encode(txt.encode("utf-8")).decode(
+            "utf-8"
+        )
+        return converted.replace("-", "a_a").replace("=", "b_b")
     except Exception as e:
         logger.error(e)
         raise e
 
+
 def base64_to_string(b64_txt: str) -> str:
-    '''
+    """
     Decode base64 string to document name
-    '''
+    """
     try:
-        converted = b64_txt.replace('a_a', '-').replace("b_b", "=")
+        converted = b64_txt.replace("a_a", "-").replace("b_b", "=")
         return base64.urlsafe_b64decode(converted).decode("utf-8")
     except Exception as e:
         logger.error(e)
@@ -50,20 +62,18 @@ def base64_to_string(b64_txt: str) -> str:
 
 class VectorCollection:
     def __init__(
-            self,
-            col_name: str,
-            doc_name: str,
-            text_field: Optional[str]="text"
-        ) -> None:
+        self, col_name: str, doc_name: str, text_field: Optional[str] = "text"
+    ) -> None:
         self.collection_name = col_name
         self.document_name = doc_name
         self.text_field = text_field
 
+
 class VectorDatabaseHostMilvus:
     def __init__(
         self,
-        embeddings: Optional[OpenAIEmbeddings]=None,
-        connection_args: Optional[dict]=None
+        embeddings: Optional[OpenAIEmbeddings] = None,
+        connection_args: Optional[dict] = None,
     ):
         self._collections: List[VectorCollection] = []
         self._embeddings: Optional[OpenAIEmbeddings] = embeddings
@@ -82,14 +92,14 @@ class VectorDatabaseHostMilvus:
         except MilvusException as e:
             logger.error(f"Failed to create connection to {host}:{port}")
             raise e
-        
+
         self._collections = []
         collections = utility.list_collections()
         for col_name in collections:
             col = Collection(col_name)
             if len(col.aliases) == 0:
                 continue
-            
+
             for alias in col.aliases:
                 matched_grp = extract_from_alias(alias)
                 if not matched_grp:
@@ -103,38 +113,45 @@ class VectorDatabaseHostMilvus:
                     VectorCollection(
                         col_name=col_name,
                         doc_name=docname,
-                        text_field=text_field
+                        text_field=text_field,
                     )
-                )                    
+                )
                 break
-    
+
     @property
     def collections(self) -> List[Dict[str, str]]:
         return [
-            {"document_name": col.document_name, "collection_name": col.collection_name}
+            {
+                "document_name": col.document_name,
+                "collection_name": col.collection_name,
+            }
             for col in self._collections
         ]
 
-    def _find_vector_collection(self, collection_name: str) -> Optional[VectorCollection]:
+    def _find_vector_collection(
+        self, collection_name: str
+    ) -> Optional[VectorCollection]:
         for obj in self._collections:
             if obj.collection_name == collection_name:
                 return obj
         return None
+
     def _remove_vector_collection(self, collection_name: str) -> bool:
         for obj in self._collections:
             if obj.collection_name == collection_name:
                 self._collections.remove(obj)
                 return True
         return False
+
     def store_embedding(
-            self, 
-            doc_name: str,
-            documents: List[Document],
-        ) -> Dict[str, str]:
+        self,
+        doc_name: str,
+        documents: List[Document],
+    ) -> Dict[str, str]:
         db = Milvus.from_documents(
             documents=documents,
             embedding=self._embeddings,
-            connection_args=self._connection_args
+            connection_args=self._connection_args,
         )
         encoded_doc_name = string_to_base64(doc_name)
         alias = f"{encoded_doc_name}_{db.collection_name}"
@@ -142,30 +159,32 @@ class VectorDatabaseHostMilvus:
         vector_collection = VectorCollection(
             col_name=db.collection_name,
             doc_name=doc_name,
-            text_field=db.text_field
+            text_field=db.text_field,
         )
         self._collections.append(vector_collection)
         return {
-            "document_name": doc_name, 
-            "collection_name": db.collection_name
+            "document_name": doc_name,
+            "collection_name": db.collection_name,
         }
-    
-    def similarity_search(self, collection_name: str, query: str, k: int=3) -> List[Document]:
+
+    def similarity_search(
+        self, collection_name: str, query: str, k: int = 3
+    ) -> List[Document]:
         vector_coll = self._find_vector_collection(collection_name)
         if not vector_coll:
             raise ValueError("No current collection loaded")
         try:
             db = Milvus(
-                embedding_function=self._embeddings, 
-                collection_name=collection_name, 
+                embedding_function=self._embeddings,
+                collection_name=collection_name,
                 connection_args=self._connection_args,
-                text_field=vector_coll.text_field
+                text_field=vector_coll.text_field,
             )
             return db.similarity_search(query=query, k=k)
         except MilvusException as e:
             logger.error(e)
             raise e
-    
+
     def drop_collection(self, collection_name: str) -> None:
         if not self._remove_vector_collection(collection_name):
             return
@@ -175,9 +194,3 @@ class VectorDatabaseHostMilvus:
         except MilvusException as e:
             logger.error(e)
             raise e
-
-
-
-
-                
-

--- a/biochatter/vectorstore_host.py
+++ b/biochatter/vectorstore_host.py
@@ -95,17 +95,17 @@ class VectorDatabaseHostMilvus:
     def get_collections(self):
         return self.collections
 
-    def _find_vector_collection(self, collection_name: str) -> int:
-        for i in range(len(self.collections)):
-            if self.collections[i].collection_name == collection_name:
-                return i
-        return -1
+    def _find_vector_collection(self, collection_name: str) -> Optional[VectorCollection]:
+        for obj in self.collections:
+            if obj.collection_name == collection_name:
+                return obj
+        return None
     def _remove_vector_collection(self, collection_name: str) -> bool:
-        ix = self._find_vector_collection(collection_name)
-        if ix < 0:
-            return False
-        self.collections.pop(ix)
-        return True
+        for obj in self.collections:
+            if obj.collection_name == collection_name:
+                self.collections.remove(obj)
+                return True
+        return False
     def store_embedding(
             self, 
             doc_name: str,
@@ -128,10 +128,9 @@ class VectorDatabaseHostMilvus:
         return vector_collection
     
     def similarity_search(self, collection_name: str, query: str, k: int=3) -> List[Document]:
-        ix = self._find_vector_collection(collection_name)
-        if ix < 0:
+        vector_coll = self._find_vector_collection(collection_name)
+        if not vector_coll:
             raise ValueError("No current collection loaded")
-        vector_coll = self.collections[ix]
         try:
             db = Milvus(
                 embedding_function=self.embeddings, 

--- a/biochatter/vectorstore_host.py
+++ b/biochatter/vectorstore_host.py
@@ -18,7 +18,7 @@ def _grab_text_field_name(fields: List[FieldSchema]) -> str | None:
     return None
 
 def extract_from_alias(alias: str) -> Optional[Tuple]:
-    # valud alias is {base64}_c{uuid4.hex}
+    # valid alias is {base64}_c{uuid4.hex}
     pattern = r"^([0-9a-zA-Z_]+)_c([a-f0-9]{32})$"
     match = re.fullmatch(pattern, alias)
     return None if not match else match.groups()

--- a/biochatter/vectorstore_host.py
+++ b/biochatter/vectorstore_host.py
@@ -1,0 +1,103 @@
+import logging
+from typing import List, Optional
+import re
+from pymilvus import MilvusException, connections, Collection, utility, FieldSchema
+from langchain.vectorstores import Milvus
+from langchain.embeddings import OpenAIEmbeddings
+
+logger = logging.getLogger(__name__)
+
+def _grab_text_field_name(fields: List[FieldSchema]) -> str | None:
+    prev_field = None
+    for x in fields:
+        if x.auto_id:
+            return prev_field.name
+        prev_field = x
+    return None
+
+class VectorCollection:
+    def __init__(
+            self,
+            col_name: str,
+            doc_name: str,
+            text_field: Optional[str]="text"
+        ) -> None:
+        self.collection_name = col_name
+        self.document_name = doc_name
+        self.text_field = text_field
+
+class VectorDatabaseHost:
+    def __init__(
+        self,
+        embeddings: Optional[OpenAIEmbeddings]=None,
+        connection_args: Optional[dict]=None
+    ):
+        self.collections: List[VectorCollection] = []
+        self.vector_db: Optional[Milvus] = None
+        self.embeddings: Optional[OpenAIEmbeddings] = embeddings
+        self.connection_args = connection_args or {
+            "host": "127.0.0.1",
+            "port": "19530",
+        }
+
+    def connect(self, host, port):
+        self.connection_args = {"host": host, "port": port}
+        self._init_host(host, port)
+
+    def _init_host(self, host, port):
+        try:
+            connections.connect(host=host, port=port)
+        except MilvusException as e:
+            logger.error(f"Failed to create connection to {host}:{port}")
+            raise e
+        
+        self.collections = []
+        self.vector_db = None
+        collections = utility.list_collections()
+        for col_name in collections:
+            col = Collection(col_name)
+            if len(col.aliases) == 0:
+                continue
+            pattern = fr"^(\w+)_{col_name}$"
+            for alias in col.aliases:
+                match = re.fullmatch(pattern, alias)
+                if not match:
+                    continue
+                text_field = _grab_text_field_name(col.schema.fields)
+                if not text_field:
+                    continue
+                grps = match.groups()
+                self.collections.append({
+                    "collection_name": col_name,
+                    "document_name": grps[0],
+                    "text_field": text_field
+                })
+                break
+    
+    def get_collections(self):
+        return self.collections
+    def get_current_collection(self) -> Optional[VectorCollection]:
+        if not self.vector_db:
+            return None
+        return self._find_collection(self.vector_db.collection_name)
+
+    def _find_collection(self, collection_name: str) -> Optional[VectorCollection]:
+        for col in self.collections:
+            if col.collection_name == collection_name:
+                return col
+        return None
+    def set_current_collection(self, collection_name):
+        col = self._find_collection(collection_name)
+        if not col:
+            logger.error(f"Unknown collection name: {collection_name}")
+            return
+        if self.vector_db and self.vector_db.collection_name == collection_name:
+            return
+        self.vector_db = Milvus(self.embeddings, self.connection_args, collection_name=collection_name, text_field=col.text_field)
+        
+    
+
+
+
+                
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "aiohttp"
-version = "3.8.4"
+version = "3.8.5"
 description = "Async http client/server framework (asyncio)"
 category = "main"
 optional = false
@@ -90,7 +90,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -125,7 +125,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 
 [[package]]
 name = "dataclasses-json"
-version = "0.5.12"
+version = "0.5.13"
 description = "Easily serialize dataclasses to and from JSON."
 category = "main"
 optional = false
@@ -457,19 +457,19 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "marshmallow"
-version = "3.19.0"
+version = "3.20.1"
 description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.dependencies]
 packaging = ">=17.0"
 
 [package.extras]
-dev = ["flake8 (==5.0.4)", "flake8-bugbear (==22.10.25)", "mypy (==0.990)", "pre-commit (>=2.4,<3.0)", "pytest", "pytz", "simplejson", "tox"]
-docs = ["alabaster (==0.7.12)", "autodocsumm (==0.2.9)", "sphinx (==5.3.0)", "sphinx-issues (==3.0.1)", "sphinx-version-warning (==1.1.2)"]
-lint = ["flake8 (==5.0.4)", "flake8-bugbear (==22.10.25)", "mypy (==0.990)", "pre-commit (>=2.4,<3.0)"]
+dev = ["flake8 (==6.0.0)", "flake8-bugbear (==23.7.10)", "mypy (==1.4.1)", "pre-commit (>=2.4,<4.0)", "pytest", "pytz", "simplejson", "tox"]
+docs = ["alabaster (==0.7.13)", "autodocsumm (==0.2.11)", "sphinx (==7.0.1)", "sphinx-issues (==3.0.1)", "sphinx-version-warning (==1.1.2)"]
+lint = ["flake8 (==6.0.0)", "flake8-bugbear (==23.7.10)", "mypy (==1.4.1)", "pre-commit (>=2.4,<4.0)"]
 tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
@@ -668,7 +668,7 @@ numpy = ">=1.16.6"
 
 [[package]]
 name = "pydantic"
-version = "1.10.11"
+version = "1.10.12"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
@@ -683,7 +683,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydeck"
-version = "0.8.1b0"
+version = "0.8.0"
 description = "Widget for deck.gl maps"
 category = "main"
 optional = true
@@ -964,7 +964,7 @@ sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "streamlit"
-version = "1.24.1"
+version = "1.25.0"
 description = "A faster way to build and share data apps"
 category = "main"
 optional = true
@@ -975,26 +975,26 @@ altair = ">=4.0,<6"
 blinker = ">=1.0.0,<2"
 cachetools = ">=4.0,<6"
 click = ">=7.0,<9"
-gitpython = ">=3,<3.1.19 || >3.1.19,<4"
+gitpython = ">=3.0.7,<3.1.19 || >3.1.19,<4"
 importlib-metadata = ">=1.4,<7"
-numpy = ">=1,<2"
-packaging = ">=14.1,<24"
-pandas = ">=0.25,<3"
-pillow = ">=6.2.0,<10"
+numpy = ">=1.19.3,<2"
+packaging = ">=16.8,<24"
+pandas = ">=1.3.0,<3"
+pillow = ">=7.1.0,<10"
 protobuf = ">=3.20,<5"
-pyarrow = ">=4.0"
-pydeck = ">=0.1.dev5,<1"
+pyarrow = ">=6.0"
+pydeck = ">=0.8,<1"
 pympler = ">=0.9,<2"
-python-dateutil = ">=2,<3"
-requests = ">=2.4,<3"
-rich = ">=10.11.0,<14"
-tenacity = ">=8.0.0,<9"
-toml = "<2"
+python-dateutil = ">=2.7.3,<3"
+requests = ">=2.18,<3"
+rich = ">=10.14.0,<14"
+tenacity = ">=8.1.0,<9"
+toml = ">=0.10.1,<2"
 tornado = ">=6.0.3,<7"
-typing-extensions = ">=4.0.1,<5"
+typing-extensions = ">=4.1.0,<5"
 tzlocal = ">=1.1,<5"
 validators = ">=0.2,<1"
-watchdog = {version = "*", markers = "platform_system != \"Darwin\""}
+watchdog = {version = ">=2.1.5", markers = "platform_system != \"Darwin\""}
 
 [package.extras]
 snowflake = ["snowflake-snowpark-python"]
@@ -1206,7 +1206,7 @@ python-versions = ">=3.8"
 
 [[package]]
 name = "urllib3"
-version = "2.0.3"
+version = "2.0.4"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -1278,93 +1278,93 @@ content-hash = "02a2923fe6ce40bbc3593d25f2300c4b385b4f395bcaad8a97fe31f68c1c64f4
 
 [metadata.files]
 aiohttp = [
-    {file = "aiohttp-3.8.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5ce45967538fb747370308d3145aa68a074bdecb4f3a300869590f725ced69c1"},
-    {file = "aiohttp-3.8.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b744c33b6f14ca26b7544e8d8aadff6b765a80ad6164fb1a430bbadd593dfb1a"},
-    {file = "aiohttp-3.8.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1a45865451439eb320784918617ba54b7a377e3501fb70402ab84d38c2cd891b"},
-    {file = "aiohttp-3.8.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a86d42d7cba1cec432d47ab13b6637bee393a10f664c425ea7b305d1301ca1a3"},
-    {file = "aiohttp-3.8.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ee3c36df21b5714d49fc4580247947aa64bcbe2939d1b77b4c8dcb8f6c9faecc"},
-    {file = "aiohttp-3.8.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:176a64b24c0935869d5bbc4c96e82f89f643bcdf08ec947701b9dbb3c956b7dd"},
-    {file = "aiohttp-3.8.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c844fd628851c0bc309f3c801b3a3d58ce430b2ce5b359cd918a5a76d0b20cb5"},
-    {file = "aiohttp-3.8.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5393fb786a9e23e4799fec788e7e735de18052f83682ce2dfcabaf1c00c2c08e"},
-    {file = "aiohttp-3.8.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e4b09863aae0dc965c3ef36500d891a3ff495a2ea9ae9171e4519963c12ceefd"},
-    {file = "aiohttp-3.8.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:adfbc22e87365a6e564c804c58fc44ff7727deea782d175c33602737b7feadb6"},
-    {file = "aiohttp-3.8.4-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:147ae376f14b55f4f3c2b118b95be50a369b89b38a971e80a17c3fd623f280c9"},
-    {file = "aiohttp-3.8.4-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:eafb3e874816ebe2a92f5e155f17260034c8c341dad1df25672fb710627c6949"},
-    {file = "aiohttp-3.8.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c6cc15d58053c76eacac5fa9152d7d84b8d67b3fde92709195cb984cfb3475ea"},
-    {file = "aiohttp-3.8.4-cp310-cp310-win32.whl", hash = "sha256:59f029a5f6e2d679296db7bee982bb3d20c088e52a2977e3175faf31d6fb75d1"},
-    {file = "aiohttp-3.8.4-cp310-cp310-win_amd64.whl", hash = "sha256:fe7ba4a51f33ab275515f66b0a236bcde4fb5561498fe8f898d4e549b2e4509f"},
-    {file = "aiohttp-3.8.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3d8ef1a630519a26d6760bc695842579cb09e373c5f227a21b67dc3eb16cfea4"},
-    {file = "aiohttp-3.8.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b3f2e06a512e94722886c0827bee9807c86a9f698fac6b3aee841fab49bbfb4"},
-    {file = "aiohttp-3.8.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3a80464982d41b1fbfe3154e440ba4904b71c1a53e9cd584098cd41efdb188ef"},
-    {file = "aiohttp-3.8.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b631e26df63e52f7cce0cce6507b7a7f1bc9b0c501fcde69742130b32e8782f"},
-    {file = "aiohttp-3.8.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f43255086fe25e36fd5ed8f2ee47477408a73ef00e804cb2b5cba4bf2ac7f5e"},
-    {file = "aiohttp-3.8.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d347a172f866cd1d93126d9b239fcbe682acb39b48ee0873c73c933dd23bd0f"},
-    {file = "aiohttp-3.8.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3fec6a4cb5551721cdd70473eb009d90935b4063acc5f40905d40ecfea23e05"},
-    {file = "aiohttp-3.8.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80a37fe8f7c1e6ce8f2d9c411676e4bc633a8462844e38f46156d07a7d401654"},
-    {file = "aiohttp-3.8.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d1e6a862b76f34395a985b3cd39a0d949ca80a70b6ebdea37d3ab39ceea6698a"},
-    {file = "aiohttp-3.8.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cd468460eefef601ece4428d3cf4562459157c0f6523db89365202c31b6daebb"},
-    {file = "aiohttp-3.8.4-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:618c901dd3aad4ace71dfa0f5e82e88b46ef57e3239fc7027773cb6d4ed53531"},
-    {file = "aiohttp-3.8.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:652b1bff4f15f6287550b4670546a2947f2a4575b6c6dff7760eafb22eacbf0b"},
-    {file = "aiohttp-3.8.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80575ba9377c5171407a06d0196b2310b679dc752d02a1fcaa2bc20b235dbf24"},
-    {file = "aiohttp-3.8.4-cp311-cp311-win32.whl", hash = "sha256:bbcf1a76cf6f6dacf2c7f4d2ebd411438c275faa1dc0c68e46eb84eebd05dd7d"},
-    {file = "aiohttp-3.8.4-cp311-cp311-win_amd64.whl", hash = "sha256:6e74dd54f7239fcffe07913ff8b964e28b712f09846e20de78676ce2a3dc0bfc"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:880e15bb6dad90549b43f796b391cfffd7af373f4646784795e20d92606b7a51"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb96fa6b56bb536c42d6a4a87dfca570ff8e52de2d63cabebfd6fb67049c34b6"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a6cadebe132e90cefa77e45f2d2f1a4b2ce5c6b1bfc1656c1ddafcfe4ba8131"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f352b62b45dff37b55ddd7b9c0c8672c4dd2eb9c0f9c11d395075a84e2c40f75"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ab43061a0c81198d88f39aaf90dae9a7744620978f7ef3e3708339b8ed2ef01"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c9cb1565a7ad52e096a6988e2ee0397f72fe056dadf75d17fa6b5aebaea05622"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:1b3ea7edd2d24538959c1c1abf97c744d879d4e541d38305f9bd7d9b10c9ec41"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:7c7837fe8037e96b6dd5cfcf47263c1620a9d332a87ec06a6ca4564e56bd0f36"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:3b90467ebc3d9fa5b0f9b6489dfb2c304a1db7b9946fa92aa76a831b9d587e99"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:cab9401de3ea52b4b4c6971db5fb5c999bd4260898af972bf23de1c6b5dd9d71"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d1f9282c5f2b5e241034a009779e7b2a1aa045f667ff521e7948ea9b56e0c5ff"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-win32.whl", hash = "sha256:5e14f25765a578a0a634d5f0cd1e2c3f53964553a00347998dfdf96b8137f777"},
-    {file = "aiohttp-3.8.4-cp36-cp36m-win_amd64.whl", hash = "sha256:4c745b109057e7e5f1848c689ee4fb3a016c8d4d92da52b312f8a509f83aa05e"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:aede4df4eeb926c8fa70de46c340a1bc2c6079e1c40ccf7b0eae1313ffd33519"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ddaae3f3d32fc2cb4c53fab020b69a05c8ab1f02e0e59665c6f7a0d3a5be54f"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4eb3b82ca349cf6fadcdc7abcc8b3a50ab74a62e9113ab7a8ebc268aad35bb9"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bcb89336efa095ea21b30f9e686763f2be4478f1b0a616969551982c4ee4c3b"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c08e8ed6fa3d477e501ec9db169bfac8140e830aa372d77e4a43084d8dd91ab"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c6cd05ea06daca6ad6a4ca3ba7fe7dc5b5de063ff4daec6170ec0f9979f6c332"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b7a00a9ed8d6e725b55ef98b1b35c88013245f35f68b1b12c5cd4100dddac333"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:de04b491d0e5007ee1b63a309956eaed959a49f5bb4e84b26c8f5d49de140fa9"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:40653609b3bf50611356e6b6554e3a331f6879fa7116f3959b20e3528783e699"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:dbf3a08a06b3f433013c143ebd72c15cac33d2914b8ea4bea7ac2c23578815d6"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:854f422ac44af92bfe172d8e73229c270dc09b96535e8a548f99c84f82dde241"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-win32.whl", hash = "sha256:aeb29c84bb53a84b1a81c6c09d24cf33bb8432cc5c39979021cc0f98c1292a1a"},
-    {file = "aiohttp-3.8.4-cp37-cp37m-win_amd64.whl", hash = "sha256:db3fc6120bce9f446d13b1b834ea5b15341ca9ff3f335e4a951a6ead31105480"},
-    {file = "aiohttp-3.8.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fabb87dd8850ef0f7fe2b366d44b77d7e6fa2ea87861ab3844da99291e81e60f"},
-    {file = "aiohttp-3.8.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:91f6d540163f90bbaef9387e65f18f73ffd7c79f5225ac3d3f61df7b0d01ad15"},
-    {file = "aiohttp-3.8.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:d265f09a75a79a788237d7f9054f929ced2e69eb0bb79de3798c468d8a90f945"},
-    {file = "aiohttp-3.8.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d89efa095ca7d442a6d0cbc755f9e08190ba40069b235c9886a8763b03785da"},
-    {file = "aiohttp-3.8.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4dac314662f4e2aa5009977b652d9b8db7121b46c38f2073bfeed9f4049732cd"},
-    {file = "aiohttp-3.8.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fe11310ae1e4cd560035598c3f29d86cef39a83d244c7466f95c27ae04850f10"},
-    {file = "aiohttp-3.8.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ddb2a2026c3f6a68c3998a6c47ab6795e4127315d2e35a09997da21865757f8"},
-    {file = "aiohttp-3.8.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e75b89ac3bd27d2d043b234aa7b734c38ba1b0e43f07787130a0ecac1e12228a"},
-    {file = "aiohttp-3.8.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6e601588f2b502c93c30cd5a45bfc665faaf37bbe835b7cfd461753068232074"},
-    {file = "aiohttp-3.8.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a5d794d1ae64e7753e405ba58e08fcfa73e3fad93ef9b7e31112ef3c9a0efb52"},
-    {file = "aiohttp-3.8.4-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:a1f4689c9a1462f3df0a1f7e797791cd6b124ddbee2b570d34e7f38ade0e2c71"},
-    {file = "aiohttp-3.8.4-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:3032dcb1c35bc330134a5b8a5d4f68c1a87252dfc6e1262c65a7e30e62298275"},
-    {file = "aiohttp-3.8.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8189c56eb0ddbb95bfadb8f60ea1b22fcfa659396ea36f6adcc521213cd7b44d"},
-    {file = "aiohttp-3.8.4-cp38-cp38-win32.whl", hash = "sha256:33587f26dcee66efb2fff3c177547bd0449ab7edf1b73a7f5dea1e38609a0c54"},
-    {file = "aiohttp-3.8.4-cp38-cp38-win_amd64.whl", hash = "sha256:e595432ac259af2d4630008bf638873d69346372d38255774c0e286951e8b79f"},
-    {file = "aiohttp-3.8.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5a7bdf9e57126dc345b683c3632e8ba317c31d2a41acd5800c10640387d193ed"},
-    {file = "aiohttp-3.8.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:22f6eab15b6db242499a16de87939a342f5a950ad0abaf1532038e2ce7d31567"},
-    {file = "aiohttp-3.8.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7235604476a76ef249bd64cb8274ed24ccf6995c4a8b51a237005ee7a57e8643"},
-    {file = "aiohttp-3.8.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea9eb976ffdd79d0e893869cfe179a8f60f152d42cb64622fca418cd9b18dc2a"},
-    {file = "aiohttp-3.8.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92c0cea74a2a81c4c76b62ea1cac163ecb20fb3ba3a75c909b9fa71b4ad493cf"},
-    {file = "aiohttp-3.8.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:493f5bc2f8307286b7799c6d899d388bbaa7dfa6c4caf4f97ef7521b9cb13719"},
-    {file = "aiohttp-3.8.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a63f03189a6fa7c900226e3ef5ba4d3bd047e18f445e69adbd65af433add5a2"},
-    {file = "aiohttp-3.8.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:10c8cefcff98fd9168cdd86c4da8b84baaa90bf2da2269c6161984e6737bf23e"},
-    {file = "aiohttp-3.8.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bca5f24726e2919de94f047739d0a4fc01372801a3672708260546aa2601bf57"},
-    {file = "aiohttp-3.8.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:03baa76b730e4e15a45f81dfe29a8d910314143414e528737f8589ec60cf7391"},
-    {file = "aiohttp-3.8.4-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:8c29c77cc57e40f84acef9bfb904373a4e89a4e8b74e71aa8075c021ec9078c2"},
-    {file = "aiohttp-3.8.4-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:03543dcf98a6619254b409be2d22b51f21ec66272be4ebda7b04e6412e4b2e14"},
-    {file = "aiohttp-3.8.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:17b79c2963db82086229012cff93ea55196ed31f6493bb1ccd2c62f1724324e4"},
-    {file = "aiohttp-3.8.4-cp39-cp39-win32.whl", hash = "sha256:34ce9f93a4a68d1272d26030655dd1b58ff727b3ed2a33d80ec433561b03d67a"},
-    {file = "aiohttp-3.8.4-cp39-cp39-win_amd64.whl", hash = "sha256:41a86a69bb63bb2fc3dc9ad5ea9f10f1c9c8e282b471931be0268ddd09430b04"},
-    {file = "aiohttp-3.8.4.tar.gz", hash = "sha256:bf2e1a9162c1e441bf805a1fd166e249d574ca04e03b34f97e2928769e91ab5c"},
+    {file = "aiohttp-3.8.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a94159871304770da4dd371f4291b20cac04e8c94f11bdea1c3478e557fbe0d8"},
+    {file = "aiohttp-3.8.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:13bf85afc99ce6f9ee3567b04501f18f9f8dbbb2ea11ed1a2e079670403a7c84"},
+    {file = "aiohttp-3.8.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2ce2ac5708501afc4847221a521f7e4b245abf5178cf5ddae9d5b3856ddb2f3a"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96943e5dcc37a6529d18766597c491798b7eb7a61d48878611298afc1fca946c"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2ad5c3c4590bb3cc28b4382f031f3783f25ec223557124c68754a2231d989e2b"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0c413c633d0512df4dc7fd2373ec06cc6a815b7b6d6c2f208ada7e9e93a5061d"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df72ac063b97837a80d80dec8d54c241af059cc9bb42c4de68bd5b61ceb37caa"},
+    {file = "aiohttp-3.8.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c48c5c0271149cfe467c0ff8eb941279fd6e3f65c9a388c984e0e6cf57538e14"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:368a42363c4d70ab52c2c6420a57f190ed3dfaca6a1b19afda8165ee16416a82"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7607ec3ce4993464368505888af5beb446845a014bc676d349efec0e05085905"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:0d21c684808288a98914e5aaf2a7c6a3179d4df11d249799c32d1808e79503b5"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:312fcfbacc7880a8da0ae8b6abc6cc7d752e9caa0051a53d217a650b25e9a691"},
+    {file = "aiohttp-3.8.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:ad093e823df03bb3fd37e7dec9d4670c34f9e24aeace76808fc20a507cace825"},
+    {file = "aiohttp-3.8.5-cp310-cp310-win32.whl", hash = "sha256:33279701c04351a2914e1100b62b2a7fdb9a25995c4a104259f9a5ead7ed4802"},
+    {file = "aiohttp-3.8.5-cp310-cp310-win_amd64.whl", hash = "sha256:6e4a280e4b975a2e7745573e3fc9c9ba0d1194a3738ce1cbaa80626cc9b4f4df"},
+    {file = "aiohttp-3.8.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ae871a964e1987a943d83d6709d20ec6103ca1eaf52f7e0d36ee1b5bebb8b9b9"},
+    {file = "aiohttp-3.8.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:461908b2578955045efde733719d62f2b649c404189a09a632d245b445c9c975"},
+    {file = "aiohttp-3.8.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:72a860c215e26192379f57cae5ab12b168b75db8271f111019509a1196dfc780"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc14be025665dba6202b6a71cfcdb53210cc498e50068bc088076624471f8bb9"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8af740fc2711ad85f1a5c034a435782fbd5b5f8314c9a3ef071424a8158d7f6b"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:841cd8233cbd2111a0ef0a522ce016357c5e3aff8a8ce92bcfa14cef890d698f"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ed1c46fb119f1b59304b5ec89f834f07124cd23ae5b74288e364477641060ff"},
+    {file = "aiohttp-3.8.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84f8ae3e09a34f35c18fa57f015cc394bd1389bce02503fb30c394d04ee6b938"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:62360cb771707cb70a6fd114b9871d20d7dd2163a0feafe43fd115cfe4fe845e"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:23fb25a9f0a1ca1f24c0a371523546366bb642397c94ab45ad3aedf2941cec6a"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:b0ba0d15164eae3d878260d4c4df859bbdc6466e9e6689c344a13334f988bb53"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:5d20003b635fc6ae3f96d7260281dfaf1894fc3aa24d1888a9b2628e97c241e5"},
+    {file = "aiohttp-3.8.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0175d745d9e85c40dcc51c8f88c74bfbaef9e7afeeeb9d03c37977270303064c"},
+    {file = "aiohttp-3.8.5-cp311-cp311-win32.whl", hash = "sha256:2e1b1e51b0774408f091d268648e3d57f7260c1682e7d3a63cb00d22d71bb945"},
+    {file = "aiohttp-3.8.5-cp311-cp311-win_amd64.whl", hash = "sha256:043d2299f6dfdc92f0ac5e995dfc56668e1587cea7f9aa9d8a78a1b6554e5755"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cae533195e8122584ec87531d6df000ad07737eaa3c81209e85c928854d2195c"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f21e83f355643c345177a5d1d8079f9f28b5133bcd154193b799d380331d5d3"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a7a75ef35f2df54ad55dbf4b73fe1da96f370e51b10c91f08b19603c64004acc"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2e2e9839e14dd5308ee773c97115f1e0a1cb1d75cbeeee9f33824fa5144c7634"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c44e65da1de4403d0576473e2344828ef9c4c6244d65cf4b75549bb46d40b8dd"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78d847e4cde6ecc19125ccbc9bfac4a7ab37c234dd88fbb3c5c524e8e14da543"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:c7a815258e5895d8900aec4454f38dca9aed71085f227537208057853f9d13f2"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:8b929b9bd7cd7c3939f8bcfffa92fae7480bd1aa425279d51a89327d600c704d"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:5db3a5b833764280ed7618393832e0853e40f3d3e9aa128ac0ba0f8278d08649"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:a0215ce6041d501f3155dc219712bc41252d0ab76474615b9700d63d4d9292af"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:fd1ed388ea7fbed22c4968dd64bab0198de60750a25fe8c0c9d4bef5abe13824"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-win32.whl", hash = "sha256:6e6783bcc45f397fdebc118d772103d751b54cddf5b60fbcc958382d7dd64f3e"},
+    {file = "aiohttp-3.8.5-cp36-cp36m-win_amd64.whl", hash = "sha256:b5411d82cddd212644cf9360879eb5080f0d5f7d809d03262c50dad02f01421a"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:01d4c0c874aa4ddfb8098e85d10b5e875a70adc63db91f1ae65a4b04d3344cda"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5980a746d547a6ba173fd5ee85ce9077e72d118758db05d229044b469d9029a"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2a482e6da906d5e6e653be079b29bc173a48e381600161c9932d89dfae5942ef"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80bd372b8d0715c66c974cf57fe363621a02f359f1ec81cba97366948c7fc873"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1161b345c0a444ebcf46bf0a740ba5dcf50612fd3d0528883fdc0eff578006a"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd56db019015b6acfaaf92e1ac40eb8434847d9bf88b4be4efe5bfd260aee692"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:153c2549f6c004d2754cc60603d4668899c9895b8a89397444a9c4efa282aaf4"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4a01951fabc4ce26ab791da5f3f24dca6d9a6f24121746eb19756416ff2d881b"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bfb9162dcf01f615462b995a516ba03e769de0789de1cadc0f916265c257e5d8"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:7dde0009408969a43b04c16cbbe252c4f5ef4574ac226bc8815cd7342d2028b6"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:4149d34c32f9638f38f544b3977a4c24052042affa895352d3636fa8bffd030a"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-win32.whl", hash = "sha256:68c5a82c8779bdfc6367c967a4a1b2aa52cd3595388bf5961a62158ee8a59e22"},
+    {file = "aiohttp-3.8.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2cf57fb50be5f52bda004b8893e63b48530ed9f0d6c96c84620dc92fe3cd9b9d"},
+    {file = "aiohttp-3.8.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:eca4bf3734c541dc4f374ad6010a68ff6c6748f00451707f39857f429ca36ced"},
+    {file = "aiohttp-3.8.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1274477e4c71ce8cfe6c1ec2f806d57c015ebf84d83373676036e256bc55d690"},
+    {file = "aiohttp-3.8.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:28c543e54710d6158fc6f439296c7865b29e0b616629767e685a7185fab4a6b9"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:910bec0c49637d213f5d9877105d26e0c4a4de2f8b1b29405ff37e9fc0ad52b8"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5443910d662db951b2e58eb70b0fbe6b6e2ae613477129a5805d0b66c54b6cb7"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2e460be6978fc24e3df83193dc0cc4de46c9909ed92dd47d349a452ef49325b7"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb1558def481d84f03b45888473fc5a1f35747b5f334ef4e7a571bc0dfcb11f8"},
+    {file = "aiohttp-3.8.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34dd0c107799dcbbf7d48b53be761a013c0adf5571bf50c4ecad5643fe9cfcd0"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aa1990247f02a54185dc0dff92a6904521172a22664c863a03ff64c42f9b5410"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:0e584a10f204a617d71d359fe383406305a4b595b333721fa50b867b4a0a1548"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:a3cf433f127efa43fee6b90ea4c6edf6c4a17109d1d037d1a52abec84d8f2e42"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:c11f5b099adafb18e65c2c997d57108b5bbeaa9eeee64a84302c0978b1ec948b"},
+    {file = "aiohttp-3.8.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:84de26ddf621d7ac4c975dbea4c945860e08cccde492269db4e1538a6a6f3c35"},
+    {file = "aiohttp-3.8.5-cp38-cp38-win32.whl", hash = "sha256:ab88bafedc57dd0aab55fa728ea10c1911f7e4d8b43e1d838a1739f33712921c"},
+    {file = "aiohttp-3.8.5-cp38-cp38-win_amd64.whl", hash = "sha256:5798a9aad1879f626589f3df0f8b79b3608a92e9beab10e5fda02c8a2c60db2e"},
+    {file = "aiohttp-3.8.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a6ce61195c6a19c785df04e71a4537e29eaa2c50fe745b732aa937c0c77169f3"},
+    {file = "aiohttp-3.8.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:773dd01706d4db536335fcfae6ea2440a70ceb03dd3e7378f3e815b03c97ab51"},
+    {file = "aiohttp-3.8.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f83a552443a526ea38d064588613aca983d0ee0038801bc93c0c916428310c28"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f7372f7341fcc16f57b2caded43e81ddd18df53320b6f9f042acad41f8e049a"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ea353162f249c8097ea63c2169dd1aa55de1e8fecbe63412a9bc50816e87b761"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d47ae48db0b2dcf70bc8a3bc72b3de86e2a590fc299fdbbb15af320d2659de"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d827176898a2b0b09694fbd1088c7a31836d1a505c243811c87ae53a3f6273c1"},
+    {file = "aiohttp-3.8.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3562b06567c06439d8b447037bb655ef69786c590b1de86c7ab81efe1c9c15d8"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4e874cbf8caf8959d2adf572a78bba17cb0e9d7e51bb83d86a3697b686a0ab4d"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6809a00deaf3810e38c628e9a33271892f815b853605a936e2e9e5129762356c"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:33776e945d89b29251b33a7e7d006ce86447b2cfd66db5e5ded4e5cd0340585c"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:eaeed7abfb5d64c539e2db173f63631455f1196c37d9d8d873fc316470dfbacd"},
+    {file = "aiohttp-3.8.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e91d635961bec2d8f19dfeb41a539eb94bd073f075ca6dae6c8dc0ee89ad6f91"},
+    {file = "aiohttp-3.8.5-cp39-cp39-win32.whl", hash = "sha256:00ad4b6f185ec67f3e6562e8a1d2b69660be43070bd0ef6fcec5211154c7df67"},
+    {file = "aiohttp-3.8.5-cp39-cp39-win_amd64.whl", hash = "sha256:c0a9034379a37ae42dea7ac1e048352d96286626251862e448933c0f59cbd79c"},
+    {file = "aiohttp-3.8.5.tar.gz", hash = "sha256:b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc"},
 ]
 aiosignal = [
     {file = "aiosignal-1.3.1-py3-none-any.whl", hash = "sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"},
@@ -1391,8 +1391,8 @@ cachetools = [
     {file = "cachetools-5.3.1.tar.gz", hash = "sha256:dce83f2d9b4e1f732a8cd44af8e8fab2dbe46201467fc98b3ef8f269092bf62b"},
 ]
 certifi = [
-    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
-    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-3.2.0.tar.gz", hash = "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"},
@@ -1480,8 +1480,8 @@ colorama = [
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 dataclasses-json = [
-    {file = "dataclasses_json-0.5.12-py3-none-any.whl", hash = "sha256:ece0f002af8d7b19c757c62b82ffb414e4bf49e856471f4070ba06590150c345"},
-    {file = "dataclasses_json-0.5.12.tar.gz", hash = "sha256:70e28da52e36f4be6b724e1f1e77fbcd19e0e0a6bf9a4c4c6e5abf713d4dab5a"},
+    {file = "dataclasses_json-0.5.13-py3-none-any.whl", hash = "sha256:97b13447f2e0b96aa6e52509040c12d70c61df8a972f3feb5cc89a6da5e177bd"},
+    {file = "dataclasses_json-0.5.13.tar.gz", hash = "sha256:425810e1356fb6917eb7c323e3aaee0c9398fc55b5001d3532381679f727fc18"},
 ]
 decorator = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
@@ -1780,8 +1780,8 @@ markupsafe = [
     {file = "MarkupSafe-2.1.3.tar.gz", hash = "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"},
 ]
 marshmallow = [
-    {file = "marshmallow-3.19.0-py3-none-any.whl", hash = "sha256:93f0958568da045b0021ec6aeb7ac37c81bfcccbb9a0e7ed8559885070b3a19b"},
-    {file = "marshmallow-3.19.0.tar.gz", hash = "sha256:90032c0fd650ce94b6ec6dc8dfeb0e3ff50c144586462c389b81a07205bedb78"},
+    {file = "marshmallow-3.20.1-py3-none-any.whl", hash = "sha256:684939db93e80ad3561392f47be0230743131560a41c5110684c16e21ade0a5c"},
+    {file = "marshmallow-3.20.1.tar.gz", hash = "sha256:5d2371bbe42000f2b3fb5eaa065224df7d8f8597bc19a1bbfa5bfe7fba8da889"},
 ]
 mdurl = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -2088,46 +2088,46 @@ pyarrow = [
     {file = "pyarrow-12.0.1.tar.gz", hash = "sha256:cce317fc96e5b71107bf1f9f184d5e54e2bd14bbf3f9a3d62819961f0af86fec"},
 ]
 pydantic = [
-    {file = "pydantic-1.10.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ff44c5e89315b15ff1f7fdaf9853770b810936d6b01a7bcecaa227d2f8fe444f"},
-    {file = "pydantic-1.10.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6c098d4ab5e2d5b3984d3cb2527e2d6099d3de85630c8934efcfdc348a9760e"},
-    {file = "pydantic-1.10.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16928fdc9cb273c6af00d9d5045434c39afba5f42325fb990add2c241402d151"},
-    {file = "pydantic-1.10.11-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0588788a9a85f3e5e9ebca14211a496409cb3deca5b6971ff37c556d581854e7"},
-    {file = "pydantic-1.10.11-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9baf78b31da2dc3d3f346ef18e58ec5f12f5aaa17ac517e2ffd026a92a87588"},
-    {file = "pydantic-1.10.11-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:373c0840f5c2b5b1ccadd9286782852b901055998136287828731868027a724f"},
-    {file = "pydantic-1.10.11-cp310-cp310-win_amd64.whl", hash = "sha256:c3339a46bbe6013ef7bdd2844679bfe500347ac5742cd4019a88312aa58a9847"},
-    {file = "pydantic-1.10.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:08a6c32e1c3809fbc49debb96bf833164f3438b3696abf0fbeceb417d123e6eb"},
-    {file = "pydantic-1.10.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a451ccab49971af043ec4e0d207cbc8cbe53dbf148ef9f19599024076fe9c25b"},
-    {file = "pydantic-1.10.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b02d24f7b2b365fed586ed73582c20f353a4c50e4be9ba2c57ab96f8091ddae"},
-    {file = "pydantic-1.10.11-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f34739a89260dfa420aa3cbd069fbcc794b25bbe5c0a214f8fb29e363484b66"},
-    {file = "pydantic-1.10.11-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:e297897eb4bebde985f72a46a7552a7556a3dd11e7f76acda0c1093e3dbcf216"},
-    {file = "pydantic-1.10.11-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d185819a7a059550ecb85d5134e7d40f2565f3dd94cfd870132c5f91a89cf58c"},
-    {file = "pydantic-1.10.11-cp311-cp311-win_amd64.whl", hash = "sha256:4400015f15c9b464c9db2d5d951b6a780102cfa5870f2c036d37c23b56f7fc1b"},
-    {file = "pydantic-1.10.11-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2417de68290434461a266271fc57274a138510dca19982336639484c73a07af6"},
-    {file = "pydantic-1.10.11-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:331c031ba1554b974c98679bd0780d89670d6fd6f53f5d70b10bdc9addee1713"},
-    {file = "pydantic-1.10.11-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8268a735a14c308923e8958363e3a3404f6834bb98c11f5ab43251a4e410170c"},
-    {file = "pydantic-1.10.11-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:44e51ba599c3ef227e168424e220cd3e544288c57829520dc90ea9cb190c3248"},
-    {file = "pydantic-1.10.11-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d7781f1d13b19700b7949c5a639c764a077cbbdd4322ed505b449d3ca8edcb36"},
-    {file = "pydantic-1.10.11-cp37-cp37m-win_amd64.whl", hash = "sha256:7522a7666157aa22b812ce14c827574ddccc94f361237ca6ea8bb0d5c38f1629"},
-    {file = "pydantic-1.10.11-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bc64eab9b19cd794a380179ac0e6752335e9555d214cfcb755820333c0784cb3"},
-    {file = "pydantic-1.10.11-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8dc77064471780262b6a68fe67e013298d130414d5aaf9b562c33987dbd2cf4f"},
-    {file = "pydantic-1.10.11-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe429898f2c9dd209bd0632a606bddc06f8bce081bbd03d1c775a45886e2c1cb"},
-    {file = "pydantic-1.10.11-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:192c608ad002a748e4a0bed2ddbcd98f9b56df50a7c24d9a931a8c5dd053bd3d"},
-    {file = "pydantic-1.10.11-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ef55392ec4bb5721f4ded1096241e4b7151ba6d50a50a80a2526c854f42e6a2f"},
-    {file = "pydantic-1.10.11-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:41e0bb6efe86281623abbeeb0be64eab740c865388ee934cd3e6a358784aca6e"},
-    {file = "pydantic-1.10.11-cp38-cp38-win_amd64.whl", hash = "sha256:265a60da42f9f27e0b1014eab8acd3e53bd0bad5c5b4884e98a55f8f596b2c19"},
-    {file = "pydantic-1.10.11-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:469adf96c8e2c2bbfa655fc7735a2a82f4c543d9fee97bd113a7fb509bf5e622"},
-    {file = "pydantic-1.10.11-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e6cbfbd010b14c8a905a7b10f9fe090068d1744d46f9e0c021db28daeb8b6de1"},
-    {file = "pydantic-1.10.11-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abade85268cc92dff86d6effcd917893130f0ff516f3d637f50dadc22ae93999"},
-    {file = "pydantic-1.10.11-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e9738b0f2e6c70f44ee0de53f2089d6002b10c33264abee07bdb5c7f03038303"},
-    {file = "pydantic-1.10.11-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:787cf23e5a0cde753f2eabac1b2e73ae3844eb873fd1f5bdbff3048d8dbb7604"},
-    {file = "pydantic-1.10.11-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:174899023337b9fc685ac8adaa7b047050616136ccd30e9070627c1aaab53a13"},
-    {file = "pydantic-1.10.11-cp39-cp39-win_amd64.whl", hash = "sha256:1954f8778489a04b245a1e7b8b22a9d3ea8ef49337285693cf6959e4b757535e"},
-    {file = "pydantic-1.10.11-py3-none-any.whl", hash = "sha256:008c5e266c8aada206d0627a011504e14268a62091450210eda7c07fabe6963e"},
-    {file = "pydantic-1.10.11.tar.gz", hash = "sha256:f66d479cf7eb331372c470614be6511eae96f1f120344c25f3f9bb59fb1b5528"},
+    {file = "pydantic-1.10.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a1fcb59f2f355ec350073af41d927bf83a63b50e640f4dbaa01053a28b7a7718"},
+    {file = "pydantic-1.10.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b7ccf02d7eb340b216ec33e53a3a629856afe1c6e0ef91d84a4e6f2fb2ca70fe"},
+    {file = "pydantic-1.10.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fb2aa3ab3728d950bcc885a2e9eff6c8fc40bc0b7bb434e555c215491bcf48b"},
+    {file = "pydantic-1.10.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:771735dc43cf8383959dc9b90aa281f0b6092321ca98677c5fb6125a6f56d58d"},
+    {file = "pydantic-1.10.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ca48477862372ac3770969b9d75f1bf66131d386dba79506c46d75e6b48c1e09"},
+    {file = "pydantic-1.10.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a5e7add47a5b5a40c49b3036d464e3c7802f8ae0d1e66035ea16aa5b7a3923ed"},
+    {file = "pydantic-1.10.12-cp310-cp310-win_amd64.whl", hash = "sha256:e4129b528c6baa99a429f97ce733fff478ec955513630e61b49804b6cf9b224a"},
+    {file = "pydantic-1.10.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b0d191db0f92dfcb1dec210ca244fdae5cbe918c6050b342d619c09d31eea0cc"},
+    {file = "pydantic-1.10.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:795e34e6cc065f8f498c89b894a3c6da294a936ee71e644e4bd44de048af1405"},
+    {file = "pydantic-1.10.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69328e15cfda2c392da4e713443c7dbffa1505bc9d566e71e55abe14c97ddc62"},
+    {file = "pydantic-1.10.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2031de0967c279df0d8a1c72b4ffc411ecd06bac607a212892757db7462fc494"},
+    {file = "pydantic-1.10.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ba5b2e6fe6ca2b7e013398bc7d7b170e21cce322d266ffcd57cca313e54fb246"},
+    {file = "pydantic-1.10.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2a7bac939fa326db1ab741c9d7f44c565a1d1e80908b3797f7f81a4f86bc8d33"},
+    {file = "pydantic-1.10.12-cp311-cp311-win_amd64.whl", hash = "sha256:87afda5539d5140cb8ba9e8b8c8865cb5b1463924d38490d73d3ccfd80896b3f"},
+    {file = "pydantic-1.10.12-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:549a8e3d81df0a85226963611950b12d2d334f214436a19537b2efed61b7639a"},
+    {file = "pydantic-1.10.12-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:598da88dfa127b666852bef6d0d796573a8cf5009ffd62104094a4fe39599565"},
+    {file = "pydantic-1.10.12-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ba5c4a8552bff16c61882db58544116d021d0b31ee7c66958d14cf386a5b5350"},
+    {file = "pydantic-1.10.12-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c79e6a11a07da7374f46970410b41d5e266f7f38f6a17a9c4823db80dadf4303"},
+    {file = "pydantic-1.10.12-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ab26038b8375581dc832a63c948f261ae0aa21f1d34c1293469f135fa92972a5"},
+    {file = "pydantic-1.10.12-cp37-cp37m-win_amd64.whl", hash = "sha256:e0a16d274b588767602b7646fa05af2782576a6cf1022f4ba74cbb4db66f6ca8"},
+    {file = "pydantic-1.10.12-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6a9dfa722316f4acf4460afdf5d41d5246a80e249c7ff475c43a3a1e9d75cf62"},
+    {file = "pydantic-1.10.12-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a73f489aebd0c2121ed974054cb2759af8a9f747de120acd2c3394cf84176ccb"},
+    {file = "pydantic-1.10.12-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b30bcb8cbfccfcf02acb8f1a261143fab622831d9c0989707e0e659f77a18e0"},
+    {file = "pydantic-1.10.12-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fcfb5296d7877af406ba1547dfde9943b1256d8928732267e2653c26938cd9c"},
+    {file = "pydantic-1.10.12-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:2f9a6fab5f82ada41d56b0602606a5506aab165ca54e52bc4545028382ef1c5d"},
+    {file = "pydantic-1.10.12-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:dea7adcc33d5d105896401a1f37d56b47d443a2b2605ff8a969a0ed5543f7e33"},
+    {file = "pydantic-1.10.12-cp38-cp38-win_amd64.whl", hash = "sha256:1eb2085c13bce1612da8537b2d90f549c8cbb05c67e8f22854e201bde5d98a47"},
+    {file = "pydantic-1.10.12-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ef6c96b2baa2100ec91a4b428f80d8f28a3c9e53568219b6c298c1125572ebc6"},
+    {file = "pydantic-1.10.12-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6c076be61cd0177a8433c0adcb03475baf4ee91edf5a4e550161ad57fc90f523"},
+    {file = "pydantic-1.10.12-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d5a58feb9a39f481eda4d5ca220aa8b9d4f21a41274760b9bc66bfd72595b86"},
+    {file = "pydantic-1.10.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5f805d2d5d0a41633651a73fa4ecdd0b3d7a49de4ec3fadf062fe16501ddbf1"},
+    {file = "pydantic-1.10.12-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:1289c180abd4bd4555bb927c42ee42abc3aee02b0fb2d1223fb7c6e5bef87dbe"},
+    {file = "pydantic-1.10.12-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5d1197e462e0364906cbc19681605cb7c036f2475c899b6f296104ad42b9f5fb"},
+    {file = "pydantic-1.10.12-cp39-cp39-win_amd64.whl", hash = "sha256:fdbdd1d630195689f325c9ef1a12900524dceb503b00a987663ff4f58669b93d"},
+    {file = "pydantic-1.10.12-py3-none-any.whl", hash = "sha256:b749a43aa51e32839c9d71dc67eb1e4221bb04af1033a32e3923d46f9effa942"},
+    {file = "pydantic-1.10.12.tar.gz", hash = "sha256:0fe8a415cea8f340e7a9af9c54fc71a649b43e8ca3cc732986116b3cb135d303"},
 ]
 pydeck = [
-    {file = "pydeck-0.8.1b0-py2.py3-none-any.whl", hash = "sha256:c89b3dd76f9991140a33b886b336c762105e9c9def8e842e891bc72dbce8a4ce"},
-    {file = "pydeck-0.8.1b0.tar.gz", hash = "sha256:9e0a67890ab061b8c6080e06f8c780934c00355a7114291c884f055f3fc0dc25"},
+    {file = "pydeck-0.8.0-py2.py3-none-any.whl", hash = "sha256:a8fa7757c6f24bba033af39db3147cb020eef44012ba7e60d954de187f9ed4d5"},
+    {file = "pydeck-0.8.0.tar.gz", hash = "sha256:07edde833f7cfcef6749124351195aa7dcd24663d4909fd7898dbd0b6fbc01ec"},
 ]
 pygments = [
     {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
@@ -2535,8 +2535,8 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.4.49.tar.gz", hash = "sha256:06ff25cbae30c396c4b7737464f2a7fc37a67b7da409993b182b024cec80aed9"},
 ]
 streamlit = [
-    {file = "streamlit-1.24.1-py2.py3-none-any.whl", hash = "sha256:569211b426ca078c0c2959a6c9a1413c2e81eca23e769fbf12308ba5bffd1f49"},
-    {file = "streamlit-1.24.1.tar.gz", hash = "sha256:fd5f0b64798e9706364408fb589b77595314a6315d13b2d750b963c7ae97f362"},
+    {file = "streamlit-1.25.0-py2.py3-none-any.whl", hash = "sha256:3c561dca1b5430e73b7f2d66bff1d26103936bb4223912ab563ffee881fccc30"},
+    {file = "streamlit-1.25.0.tar.gz", hash = "sha256:8a7c93bee8703869045804afe22e9373c4e974fdb2a3e9abe3b027df3de03119"},
 ]
 tenacity = [
     {file = "tenacity-8.2.2-py3-none-any.whl", hash = "sha256:2f277afb21b851637e8f52e6a613ff08734c347dc19ade928e519d7d2d8569b0"},
@@ -2728,8 +2728,8 @@ ujson = [
     {file = "ujson-5.8.0.tar.gz", hash = "sha256:78e318def4ade898a461b3d92a79f9441e7e0e4d2ad5419abed4336d702c7425"},
 ]
 urllib3 = [
-    {file = "urllib3-2.0.3-py3-none-any.whl", hash = "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1"},
-    {file = "urllib3-2.0.3.tar.gz", hash = "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"},
+    {file = "urllib3-2.0.4-py3-none-any.whl", hash = "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"},
+    {file = "urllib3-2.0.4.tar.gz", hash = "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"},
 ]
 validators = [
     {file = "validators-0.20.0.tar.gz", hash = "sha256:24148ce4e64100a2d5e267233e23e7afeb55316b47d30faae7eb6e7292bc226a"},

--- a/test/test_llm_connect.py
+++ b/test/test_llm_connect.py
@@ -10,6 +10,7 @@ from biochatter.llm_connect import (
 from openai.error import InvalidRequestError
 import pytest
 
+
 def test_empty_messages():
     convo = GptConversation(
         model_name="gpt-3.5-turbo",
@@ -99,4 +100,4 @@ def test_azure():
         base=os.getenv("OPENAI_API_BASE"),
     )
 
-    convo.set_api_key(os.getenv("OPENAI_API_KEY"))
+    assert convo.set_api_key(os.getenv("OPENAI_API_KEY"))

--- a/test/test_vectorstore.py
+++ b/test/test_vectorstore.py
@@ -6,7 +6,9 @@ from biochatter.vectorstore import (
 
 import pytest
 import os
+
 print(os.getcwd())
+
 
 def test_document_summariser():
     # runs long, requires OpenAI API key and local milvus server
@@ -37,7 +39,7 @@ def test_document_summariser():
     assert cnt > 0
     docsum.drop_collection(collection["collection_name"])
     collections = docsum.get_all_collections()
-    assert (cnt-1) == len(collections)
+    assert (cnt - 1) == len(collections)
 
 
 def test_load_txt():
@@ -82,10 +84,16 @@ def test_byte_pdf():
     assert isinstance(doc[0], Document)
     assert "numerous attempts at standardising KGs" in doc[0].page_content
 
+
 CHUNK_SIZE = 100
 CHUNK_OVERLAP = 10
 
-def check_document_splitter(docsum: DocumentEmbedder, fn: str, expected_length: int):
+
+def check_document_splitter(
+    docsum: DocumentEmbedder,
+    fn: str,
+    expected_length: int,
+):
     reader = DocumentReader()
     docsum.set_document(reader.load_document(fn))
     docsum.split_document()
@@ -96,32 +104,33 @@ def test_split_by_characters():
     # requires OpenAI API key
     docsum = DocumentEmbedder(
         chunk_size=CHUNK_SIZE,
-        chunk_overlap=CHUNK_OVERLAP
+        chunk_overlap=CHUNK_OVERLAP,
     )
     check_document_splitter(docsum, "test/bc_summary.pdf", 197)
     check_document_splitter(docsum, "test/dcn.pdf", 245)
     check_document_splitter(docsum, "test/bc_summary.txt", 104)
+
 
 def test_split_by_tokens_tiktoken():
     # requires OpenAI API key
     docsum = DocumentEmbedder(
         split_by_characters=False,
         chunk_size=CHUNK_SIZE,
-        chunk_overlap=CHUNK_OVERLAP
+        chunk_overlap=CHUNK_OVERLAP,
     )
     check_document_splitter(docsum, "test/bc_summary.pdf", 73)
     check_document_splitter(docsum, "test/dcn.pdf", 104)
     check_document_splitter(docsum, "test/bc_summary.txt", 37)
 
+
 def test_split_by_tokens_tokenizers():
     # requires OpenAI API key
     docsum = DocumentEmbedder(
-        split_by_characters=False, 
+        split_by_characters=False,
         model="bigscience/bloom",
         chunk_size=CHUNK_SIZE,
-        chunk_overlap=CHUNK_OVERLAP
+        chunk_overlap=CHUNK_OVERLAP,
     )
     check_document_splitter(docsum, "test/bc_summary.pdf", 79)
     check_document_splitter(docsum, "test/dcn.pdf", 111)
     check_document_splitter(docsum, "test/bc_summary.txt", 40)
-

--- a/test/test_vectorstore.py
+++ b/test/test_vectorstore.py
@@ -4,14 +4,9 @@ from biochatter.vectorstore import (
     Document,
 )
 
+import pytest
 import os
 print(os.getcwd())
-
-try:
-    from dotenv import load_dotenv
-    load_dotenv()
-except Exception:
-    pass
 
 def test_document_summariser():
     # runs long, requires OpenAI API key and local milvus server
@@ -84,12 +79,14 @@ CHUNK_SIZE = 100
 CHUNK_OVERLAP = 10
 
 def check_document_splitter(docsum: DocumentEmbedder, fn: str, expected_length: int):
-    docsum._load_document(fn)
+    reader = DocumentReader()
+    docsum.set_document(reader.load_document(fn))
     docsum.split_document()
     assert expected_length == len(docsum.split)
 
 
 def test_split_by_characters():
+    # requires OpenAI API key
     docsum = DocumentEmbedder(
         chunk_size=CHUNK_SIZE,
         chunk_overlap=CHUNK_OVERLAP
@@ -99,6 +96,7 @@ def test_split_by_characters():
     check_document_splitter(docsum, "test/bc_summary.txt", 104)
 
 def test_split_by_tokens_tiktoken():
+    # requires OpenAI API key
     docsum = DocumentEmbedder(
         split_by_characters=False,
         chunk_size=CHUNK_SIZE,
@@ -109,6 +107,7 @@ def test_split_by_tokens_tiktoken():
     check_document_splitter(docsum, "test/bc_summary.txt", 37)
 
 def test_split_by_tokens_tokenizers():
+    # requires OpenAI API key
     docsum = DocumentEmbedder(
         split_by_characters=False, 
         model="bigscience/bloom",

--- a/test/test_vectorstore.py
+++ b/test/test_vectorstore.py
@@ -24,13 +24,20 @@ def test_document_summariser():
     assert isinstance(docsum.split, list)
     assert isinstance(docsum.split[0], Document)
 
-    docsum.store_embeddings()
-    assert docsum.vector_db is not None
+    collection = docsum.store_embeddings(doc_name="bc_summary.pdf")
+    assert docsum.current_collection_name is not None
 
     query = "What is BioCypher?"
     results = docsum.similarity_search(query)
     assert len(results) == 3
     assert all(["BioCypher" in result.page_content for result in results])
+
+    collections = docsum.get_all_collections()
+    cnt = len(collections)
+    assert cnt > 0
+    docsum.drop_collection(collection["collection_name"])
+    collections = docsum.get_all_collections()
+    assert (cnt-1) == len(collections)
 
 
 def test_load_txt():

--- a/test/test_vectorstore_host.py
+++ b/test/test_vectorstore_host.py
@@ -15,10 +15,14 @@ from biochatter.vectorstore_host import (
 )
 
 """
-This test need OPENAI API KEY and local milvus server
+This test needs OPENAI_API_KEY in the environment and a local milvus server
 """
 
-_HOST = "127.0.0.1"
+# setup milvus connection
+if os.getenv("DEVCONTAINER"):
+    _HOST = "milvus-standalone"
+else:
+    _HOST = "127.0.0.1"
 _PORT = "19530"
 collection_names = []
 

--- a/test/test_vectorstore_host.py
+++ b/test/test_vectorstore_host.py
@@ -1,4 +1,3 @@
-
 import os
 import pytest
 from typing import List
@@ -9,43 +8,53 @@ from langchain.schema import Document
 from pymilvus import utility, Collection
 
 from biochatter.vectorstore import DocumentReader
-from biochatter.vectorstore_host import VectorDatabaseHostMilvus, base64_to_string, string_to_base64
+from biochatter.vectorstore_host import (
+    VectorDatabaseHostMilvus,
+    base64_to_string,
+    string_to_base64,
+)
 
-'''
+"""
 This test need OPENAI API KEY and local milvus server
-'''
+"""
 
 _HOST = "127.0.0.1"
 _PORT = "19530"
 collection_names = []
-def prepare_splitted_documents(doc_path: str, chunk_size:int=1000, chunk_overlap:int=20) -> List[Document]:
+
+
+def prepare_splitted_documents(
+    doc_path: str, chunk_size: int = 1000, chunk_overlap: int = 20
+) -> List[Document]:
     pdf_path = doc_path
     reader = DocumentReader()
     docs = reader.load_document(pdf_path)
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=chunk_size,
-        chunk_overlap = chunk_overlap,
-        separators = [" ", ",", "\n"]
+        chunk_overlap=chunk_overlap,
+        separators=[" ", ",", "\n"],
     )
     return text_splitter.split_documents(docs)
-    
+
+
 def setup_module(module):
     pdf_path = "test/bc_summary.pdf"
     splitted_docs = prepare_splitted_documents(pdf_path)
     docname = string_to_base64(os.path.basename(pdf_path))
     db = Milvus.from_documents(
-        documents=splitted_docs, 
+        documents=splitted_docs,
         embedding=OpenAIEmbeddings(),
-        connection_args={"host": _HOST, "port": _PORT}
+        connection_args={"host": _HOST, "port": _PORT},
     )
     utility.create_alias(db.collection_name, f"{docname}_{db.collection_name}")
     collection_names.append(db.collection_name)
-    
+
 
 def teardown_module(module):
     for name in collection_names:
         col = Collection(name)
         col.drop()
+
 
 def test_connect_host():
     # require local milvus server
@@ -54,6 +63,7 @@ def test_connect_host():
     collections = dbHost.collections
     assert not collections is None
     assert len(collections) > 0
+
 
 def test_store_embeddings_and_similarity_search():
     dbHost = VectorDatabaseHostMilvus(embeddings=OpenAIEmbeddings())
@@ -64,12 +74,16 @@ def test_store_embeddings_and_similarity_search():
 
     results = dbHost.similarity_search(
         collection_name=vector_collection["collection_name"],
-        query="What is Deep Counterfactual Networks?", 
-        k=3
+        query="What is Deep Counterfactual Networks?",
+        k=3,
     )
     assert len(results) > 0
-    assert all(["Deep Counterfactual Networks" in item.page_content for item in results])
+    assert all(
+        [
+            "Deep Counterfactual Networks" in item.page_content
+            for item in results
+        ]
+    )
     cnt = len(dbHost.collections)
     dbHost.drop_collection(vector_collection["collection_name"])
     assert (cnt - 1) == len(dbHost.collections)
-    

--- a/test/test_vectorstore_host.py
+++ b/test/test_vectorstore_host.py
@@ -1,8 +1,49 @@
 
-from biochatter.vectorstore_host import VectorDatabaseHost
+import os
+
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores import Milvus
+from langchain.embeddings import OpenAIEmbeddings
+from pymilvus import utility, Collection
+
+from biochatter.vectorstore import DocumentReader
+from biochatter.vectorstore_host import VectorDatabaseHost, base64_to_string, string_to_base64
+
+'''
+This test need OPENAI API KEY and local milvus server
+'''
 
 _HOST = "127.0.0.1"
 _PORT = "19530"
+collection_names = []
+def prepare_collection(doc_path: str) -> Milvus:
+    pdf_path = doc_path
+    docname = string_to_base64(os.path.basename(pdf_path))
+    reader = DocumentReader()
+    docs = reader.load_document(pdf_path)
+    text_splitter = RecursiveCharacterTextSplitter(
+        chunk_size=100,
+        chunk_overlap = 10,
+        separators = [" ", ",", "\n"]
+    )
+    splitted_docs = text_splitter.split_documents(docs)
+    db = Milvus.from_documents(
+        documents=splitted_docs, 
+        embedding=OpenAIEmbeddings(),
+        connection_args={"host": _HOST, "port": _PORT}
+    )
+    
+    utility.create_alias(db.collection_name, f"{docname}_{db.collection_name}")
+    collection_names.append(db.collection_name)
+def setup_module(module):
+    prepare_collection("test/bc_summary.pdf")
+    
+
+def teardown_module(module):
+    for name in collection_names:
+        col = Collection(name)
+        col.drop()
+
 
 def test_connect_host():
     # require local milvus server
@@ -12,3 +53,13 @@ def test_connect_host():
     assert not collections is None
     cur_collection = dbHost.get_current_collection()
     assert cur_collection is None
+
+def test_set_current_collection():
+    dbHost = VectorDatabaseHost()
+    dbHost.connect(host=_HOST, port=_PORT)
+    collections = dbHost.get_collections()
+    assert len(collections) > 0
+    dbHost.set_current_collection(collections[0].collection_name)
+    cur_collection = dbHost.get_current_collection()
+    assert cur_collection is not None
+    assert cur_collection.collection_name == collections[0].collection_name

--- a/test/test_vectorstore_host.py
+++ b/test/test_vectorstore_host.py
@@ -69,5 +69,7 @@ def test_store_embeddings_and_similarity_search():
     )
     assert len(results) > 0
     assert all(["Deep Counterfactual Networks" in item.page_content for item in results])
+    cnt = len(dbHost.get_collections())
     dbHost.drop_collection(vector_collection.collection_name)
+    assert (cnt - 1) == len(dbHost.get_collections())
     

--- a/test/test_vectorstore_host.py
+++ b/test/test_vectorstore_host.py
@@ -1,0 +1,14 @@
+
+from biochatter.vectorstore_host import VectorDatabaseHost
+
+_HOST = "127.0.0.1"
+_PORT = "19530"
+
+def test_connect_host():
+    # require local milvus server
+    dbHost = VectorDatabaseHost()
+    dbHost.connect(host=_HOST, port=_PORT)
+    collections = dbHost.get_collections()
+    assert not collections is None
+    cur_collection = dbHost.get_current_collection()
+    assert cur_collection is None

--- a/test/test_vectorstore_host.py
+++ b/test/test_vectorstore_host.py
@@ -51,7 +51,7 @@ def test_connect_host():
     # require local milvus server
     dbHost = VectorDatabaseHostMilvus()
     dbHost.connect(host=_HOST, port=_PORT)
-    collections = dbHost.get_collections()
+    collections = dbHost.collections
     assert not collections is None
     assert len(collections) > 0
 
@@ -63,13 +63,13 @@ def test_store_embeddings_and_similarity_search():
     vector_collection = dbHost.store_embedding("dcn.pdf", splitted_docs)
 
     results = dbHost.similarity_search(
-        collection_name=vector_collection.collection_name,
+        collection_name=vector_collection["collection_name"],
         query="What is Deep Counterfactual Networks?", 
         k=3
     )
     assert len(results) > 0
     assert all(["Deep Counterfactual Networks" in item.page_content for item in results])
-    cnt = len(dbHost.get_collections())
-    dbHost.drop_collection(vector_collection.collection_name)
-    assert (cnt - 1) == len(dbHost.get_collections())
+    cnt = len(dbHost.collections)
+    dbHost.drop_collection(vector_collection["collection_name"])
+    assert (cnt - 1) == len(dbHost.collections)
     


### PR DESCRIPTION
### Abstract
This submission is to enable DocumentEmbedder to connect to remote host. The key changes are:
1. Introduced class VectorDatabaseHostMilvus, its APIs:
- **connect(host, port)**, connect to local/remote milvus server, and read all existed collections
- **store_embeddings(doc_name, splits)**, create a new collection and store embeddings to milvus server. Moreover, this function also encode document name to collection alias
- **similarity_search(collection_name, query, k)**, similarity search by query text in specified collection
- **drop_collection(collection_name)**, delete specified collection

2. In **DocumentEmbedder**, we temporarily introduced attribute **current_collection_name**. This avoids breaking existing ChatGSE code. Once ChatGSE is updated to store and pass current collection name with each request, we can remove this temporary attribute.

### Expected workflow to connect to remote host:
1). In ChatGSE, when document summarization is enabled, VectorDatabaseHostMilvus will be instantiated and connect() be called to connect to local milvus server, and read all collections.
2). ChatGSE gets all existed collections and their document names,  and display them to enable customers to choose from.
3). When customers ask a question, ChatGSE calls Conversation.query() and passes current collection name to biochatter
4). When customer connects to remote milvus server, connect() will be called, and all existed collections in server will be read, then continue to step 2)

### Tests
added test/test_vectorstore_host.py