### PR TITLE
fix: don't add `None` to entities if source or target are missing

### DIFF
--- a/biochatter/prompts.py
+++ b/biochatter/prompts.py
@@ -407,9 +407,13 @@ class BioCypherPromptEngine:
                 sources = ensure_iterable(value["source"])
                 targets = ensure_iterable(value["target"])
                 for source in sources:
+                    if source is None:
+                        continue
                     if source not in self.selected_entities:
                         self.selected_entities.append(source)
                 for target in targets:
+                    if target is None:
+                        continue
                     if target not in self.selected_entities:
                         self.selected_entities.append(target)
 

--- a/test/test_prompts.py
+++ b/test/test_prompts.py
@@ -24,6 +24,7 @@ def test_biocypher_prompts(prompt_engine):
         "CellType",
     ]
     assert list(prompt_engine.relationships.keys()) == [
+        "PostTranslationalInteraction",
         "Phosphorylation",
         "GeneToPhenotypeAssociation",
         "GeneToDiseaseAssociation",
@@ -156,6 +157,26 @@ def test_relationship_selection_with_incomplete_entities(prompt_engine):
         )
 
         assert "Protein" in prompt_engine.selected_entities
+
+
+def test_relationship_selection_does_not_create_none_entities(prompt_engine):
+    prompt_engine.question = "Which proteins interact post-translationally?"
+    prompt_engine.selected_entities = ["Protein"]
+    with patch("biochatter.prompts.Conversation") as mock_conversation:
+        mock_conversation.return_value.query.return_value = [
+            "PostTranslationalInteraction",
+            Mock(),
+            None,
+        ]
+        mock_append_system_messages = Mock()
+        mock_conversation.return_value.append_system_message = (
+            mock_append_system_messages
+        )
+        success = prompt_engine._select_relationships(
+            conversation=mock_conversation.return_value
+        )
+        assert success
+        assert None not in prompt_engine.selected_entities
 
 
 def test_property_selection(prompt_engine):

--- a/test/test_schema_info.yaml
+++ b/test/test_schema_info.yaml
@@ -61,7 +61,7 @@ cell type:
 post translational interaction:
   is_a: pairwise molecular interaction
   is_relationship: true
-  present_in_knowledge_graph: false
+  present_in_knowledge_graph: true
   represented_as: node
   label_as_edge: INTERACTS_POST_TRANSLATIONAL
   input_label: post_translational


### PR DESCRIPTION
This is to fix the issue that BioChatter creates `None` entities if the source or target are not given in a relationship's schema definition, which are then obviously not found in the entity dictionary downstream of relationship selection.