### PR TITLE
Extended benchmarking cases

### DIFF
--- a/benchmark/data/benchmark_kg_schema_data.yaml
+++ b/benchmark/data/benchmark_kg_schema_data.yaml
@@ -3,7 +3,7 @@
 #
 # Test case keys:
 # - input (for creating the test)
-# - expected (for asserting outcomes and generating a score)
+# - expected (for asserting ourcomes and generating a score)
 # - case (for categorizing the test case)
 #
 # If any input is a dictionary itself, it will be expanded into separate test
@@ -334,3 +334,216 @@ kg_schemas:
       source: chemical
       target: web page
       input_label: chemical_webpage
+
+  hetionet:
+    gene:
+      input_label:
+        - hgnc
+        - ensg
+      is_relationship: false
+      preferred_id: hgnc
+      present_in_knowledge_graph: true
+      properties:
+        symbol: str
+        name: str
+        description: str
+        taxon: int
+      represented_as: node
+    disease:
+      input_label: Disease
+      is_relationship: false
+      preferred_id: doid
+      present_in_knowledge_graph: true
+      properties:
+        name: str
+        mesh_id: str
+        umls_id: str
+      represented_as: node
+    compound:
+      input_label: Compound
+      is_relationship: false
+      preferred_id: drugbank
+      present_in_knowledge_graph: true
+      properties:
+        name: str
+        smiles: str
+        inchi: str
+      represented_as: node
+    pathway:
+      input_label: Pathway
+      is_relationship: false
+      preferred_id:
+        - reactome
+        - kegg
+      present_in_knowledge_graph: true
+      properties:
+        name: str
+        source: str
+      represented_as: node
+    anatomy:
+      input_label: Anatomy
+      is_relationship: false
+      preferred_id: uberon
+      present_in_knowledge_graph: true
+      properties:
+        name: str
+      represented_as: node
+    gene-disease association:
+      input_label: gene_disease_association
+      is_relationship: true
+      label_as_edge: ASSOCIATED_WITH
+      present_in_knowledge_graph: true
+      properties:
+        score: float
+        evidence: str
+      represented_as: edge
+      source: gene
+      target: disease
+    compound-disease treatment:
+      input_label: compound_treats_disease
+      is_relationship: true
+      label_as_edge: TREATS
+      present_in_knowledge_graph: true
+      properties:
+        phase: int
+        source: str
+      represented_as: edge
+      source: compound
+      target: disease
+    gene-compound interaction:
+      input_label: gene_compound_interaction
+      is_relationship: true
+      label_as_edge: INTERACTS_WITH
+      present_in_knowledge_graph: true
+      properties:
+        action: str
+        affinity: float
+      represented_as: edge
+      source: gene
+      target: compound
+    pathway-disease association:
+      input_label: pathway_disease_association
+      is_relationship: true
+      label_as_edge: INVOLVED_IN
+      present_in_knowledge_graph: true
+      properties:
+        evidence: str
+        source: str
+      represented_as: edge
+      source: pathway
+      target: disease
+    gene-pathway association:
+      input_label: gene_pathway_association
+      is_relationship: true
+      label_as_edge: PARTICIPATES_IN
+      present_in_knowledge_graph: true
+      properties:
+        evidence: str
+      represented_as: edge
+      source: gene
+      target: pathway
+    disease-symptom association:
+      input_label: disease_symptom_association
+      is_relationship: true
+      label_as_edge: ASSOCIATED_WITH_SYMPTOM
+      present_in_knowledge_graph: true
+      properties:
+        source: str
+        evidence: str
+      represented_as: edge
+      source: disease
+      target: symptom
+    side effect:
+      input_label: side_effect
+      is_relationship: true
+      label_as_edge: CAUSES_SIDE_EFFECT
+      present_in_knowledge_graph: true
+      properties:
+        severity: str
+      represented_as: edge
+      source: compound
+      target: symptom
+  
+  open-targets:
+    human gene:
+      is_a: gene
+      represented_as: node
+      preferred_id: ensembl
+      input_label: ensembl
+      properties:
+        approvedSymbol: str
+        approvedName: str
+        biotype: str
+    mouse gene:
+      is_a: gene
+      represented_as: node
+      preferred_id: ensembl
+      input_label: mouse gene
+      properties:
+        targetInModel: str
+        targetInModelMgiId: str
+        targetFromSourceId: str
+    # otar has no Bioregistry entry
+    disease:
+      represented_as: node
+      preferred_id: [mondo, efo, hp, orphanet, otar, oba, ncit, doid, obi, ogms]
+      input_label: [mondo, efo, hp, orphanet, otar, oba, ncit, doid, obi, ogms]
+      properties:
+        code: str
+        name: str
+        description: str
+        ontology: str
+    drug:
+      represented_as: node
+      preferred_id: chembl
+      input_label: chembl
+      properties:
+        name: str
+        description: str
+    go term:
+      is_a: biological entity # activity, process, or location
+      represented_as: node
+      preferred_id: go
+      input_label: go
+      properties:
+        name: str
+    mouse phenotype:
+      is_a: phenotypic feature
+      represented_as: node
+      preferred_id: mp
+      input_label: mp
+      properties:
+        modelPhenotypeLabel: str
+        targetFromSourceId: str
+        targetInModelEnsemblId: str
+    gene to disease association:
+      represented_as: edge
+      preferred_id:
+        [
+          affected pathway,
+          somatic mutation,
+          genetic association,
+          literature,
+          animal model,
+          known drug,
+          rna expression,
+        ]
+      input_label:
+        [
+          affected_pathway,
+          somatic_mutation,
+          genetic_association,
+          literature,
+          animal_model,
+          known_drug,
+          rna_expression,
+        ]
+      properties:
+        literature: str[]
+        score: double
+    gene to go term association:
+      is_a: association
+      represented_as: edge
+      source: gene
+      target: go term
+      input_label: GENE_TO_GO_TERM_ASSOCIATION

--- a/benchmark/data/benchmark_query_test_data.yaml
+++ b/benchmark/data/benchmark_query_test_data.yaml
@@ -3,7 +3,7 @@
 #
 # Test case keys:
 # - input (for creating the test)
-# - expected (for asserting outcomes and generating a score)
+# - expected (for asserting ourcomes and generating a score)
 # - case (for categorizing the test case)
 #
 # If any input is a dictionary itself, it will be expanded into separate test
@@ -15,6 +15,7 @@ biocypher_query_generation:
     input:
       kg_schema: gene_kg
       prompt: What is the name of the disease with ICD10 code 'E10'?
+      language: Cypher
     expected:
       entities: ["Disease"]
       relationships: []
@@ -29,11 +30,338 @@ biocypher_query_generation:
           "WHERE [a-zA-Z]*\\.ICD10|{ICD10:",
         ]
 
+  # test additional simple cypher query
+  - case: simple2
+    input:
+      kg_schema: gene_kg
+      prompt: What is the name of the gene with ID '6091'?
+      language: Cypher
+    expected:
+      entities: ["Disease"]
+      relationships: []
+      relationship_labels: {}
+      properties:
+        Gene: ["name", "INSR"]
+      parts_of_query:
+        [
+          "^MATCH",
+          "RETURN",
+          "([a-zA-Z]*:Gene)",
+          "WHERE [a-zA-Z]*\\.id|{id:",
+        ]
+
+  # test additional simple SQL query
+  - case: simple2_SQL
+    input:
+      kg_schema: gene_kg
+      prompt: What is the name of the gene with ID '6091'?
+      language: SQL
+    expected:
+      entities: ["Disease"]
+      relationships: []
+      relationship_labels: {}
+      properties:
+        Gene: ["name", "INSR"]
+      parts_of_query:
+        [
+          "^SELECT",
+          "FROM",
+          "\\s*Gene",
+          "(?i)WHERE\\s+id\\s*=\\s*'6091'",
+          ";$"
+        ]
+
+  # test ability to answer OTAR question
+  - case: OTAR1
+    input:
+      kg_schema: gene_kg
+      prompt: Which cell types are relevant for NASH disease?
+      language: Cypher
+    expected:
+      entities: ["cell_type", "Disease", "Gene", "Protein"]
+      relationships: ["PERTURBED_IN", "GENE_TO_PROTEIN_ASSOCIATION", "GENE_EXPRESSED_IN_CELL_TYPE"]
+      relationship_labels:
+        PERTURBED_IN:
+          source: Protein
+          target: Disease
+        GENE_TO_PROTEIN_ASSOCIATION:
+          source: Gene
+          target: Protein
+        GENE_EXPRESSED_IN_CELL_TYPE:
+          source: Gene
+          target: cell_type
+      properties:
+        Disease: ["name", "ICD10", "DSM5"]
+        cell_type: ["cell_type_name", "medium", "organism"]
+        Gene: ["id", "name", "taxon"]
+        Protein: ["name", "genes", "score", "taxon"]
+        PERTURBED_IN: ["evidence", "score", "source"]
+        GENE_TO_PROTEIN_ASSOCIATION: ["evidence", "score", "source"]
+        GENE_EXPRESSED_IN_CELL_TYPE: ["expression_level"]
+      parts_of_query:
+        [
+          "^MATCH",
+          "([a-zA-Z]*:Disease)",
+          "([a-zA-Z]*:Protein)",
+          "([a-zA-Z]*:Gene)",
+          "([a-zA-Z]*:cell_type)",
+          "\\(.*?\\)-\\[:PERTURBED_IN\\]->\\(.*?\\)",
+          "\\(.*?\\)-\\[:GENE_TO_PROTEIN_ASSOCIATION\\]->\\(.*?\\)",
+          "\\(.*?\\)-\\[:GENE_EXPRESSED_IN_CELL_TYPE\\]->\\(.*?\\)",
+          "NASH",
+          "RETURN\\s+(DISTINCT\\s+)?cell_type\\.name",
+        ]
+
+  # test ability to answer OTAR question with SQL
+  - case: OTAR1_SQL
+    input:
+      kg_schema: gene_kg
+      prompt: Which cell types are relevant for NASH disease?
+      language: SQL
+    expected:
+      entities: ["cell_type", "Disease", "Gene", "Protein"]
+      relationships: ["PERTURBED_IN", "GENE_TO_PROTEIN_ASSOCIATION", "GENE_EXPRESSED_IN_CELL_TYPE"]
+      relationship_labels:
+        PERTURBED_IN:
+          source: Protein
+          target: Disease
+        GENE_TO_PROTEIN_ASSOCIATION:
+          source: Gene
+          target: Protein
+        GENE_EXPRESSED_IN_CELL_TYPE:
+          source: Gene
+          target: cell_type
+      properties:
+        Disease: ["name", "ICD10", "DSM5"]
+        cell_type: ["cell_type_name", "medium", "organism"]
+        Gene: ["id", "name", "taxon"]
+        Protein: ["name", "genes", "score", "taxon"]
+        PERTURBED_IN: ["evidence", "score", "source"]
+        GENE_TO_PROTEIN_ASSOCIATION: ["evidence", "score", "source"]
+        GENE_EXPRESSED_IN_CELL_TYPE: ["expression_level"]
+      parts_of_query:
+          [
+            "SELECT\\s+cell_type\\.cell_type_name",  # Matches the SELECT clause for cell_type_name
+            "FROM\\s+cell_type",                       # Matches the FROM clause
+            "JOIN\\s+Gene_EXPRESSED_IN_CELL_TYPE\\s+.*",  # Matches the JOIN with Gene_EXPRESSED_IN_CELL_TYPE
+            "JOIN\\s+Gene\\s+.*",                     # Matches the JOIN with Gene
+            "JOIN\\s+GENE_TO_PROTEIN_ASSOCIATION\\s+.*",  # Matches the JOIN with GENE_TO_PROTEIN_ASSOCIATION
+            "JOIN\\s+Protein\\s+.*",                  # Matches the JOIN with Protein
+            "JOIN\\s+PERTURBED_IN\\s+.*",             # Matches the JOIN with PERTURBED_IN
+            "JOIN\\s+Disease\\s+.*",                  # Matches the JOIN with Disease
+            "WHERE\\s+Disease\\.name\\s*=\\s*'NASH'\\s*;$"  # Matches the WHERE clause for Disease.name = 'NASH'
+          ]
+
+  # test ability to answer OTAR question with hetionet scheme
+  - case: OTAR1_hetionet
+    input:
+      kg_schema: hetionet
+      prompt: Which cell types are relevant for NASH disease?
+      language: Cypher
+    expected:
+      entities: ["cell_type", "Disease", "Gene", "Compound"]
+      relationships: ["ASSOCIATED_WITH", "INTERACTS_WITH", "PARTICIPATES_IN"]
+      relationship_labels:
+        ASSOCIATED_WITH:
+          source: Gene
+          target: Disease
+        INTERACTS_WITH:
+          source: Gene
+          target: Compound
+        PARTICIPATES_IN:
+          source: Gene
+          target: cell_type
+      properties:
+        Disease: ["name", "mesh_id", "umls_id"]
+        cell_type: ["name"]
+        Gene: ["symbol", "name", "description", "taxon"]
+        Compound: ["name", "smiles", "inchi"]
+        ASSOCIATED_WITH: ["score", "evidence"]
+        INTERACTS_WITH: ["action", "affinity"]
+        PARTICIPATES_IN: ["evidence"]
+      parts_of_query:
+          [
+            "^MATCH",
+            "DISTINCT",
+            "([a-zA-Z]*:Gene)",
+            "([a-zA-Z]*:Disease)",
+            "([a-zA-Z]*:cell_type)",
+            "NASH",
+            "\\(.*:Gene\\)-\\[:PARTICIPATES_IN\\]-|-\\[:PARTICIPATES_IN\\]-\\(.*:Gene\\)",
+            "RETURN\\s+(DISTINCT\\s+)?cell_type\\.name",
+          ]
+
+  # test ability to answer OTAR question with open-targets scheme
+  - case: OTAR1_open_targets
+    input:
+      kg_schema: open-targets
+      prompt: Which cell types are relevant for NASH disease?
+      language: Cypher
+    expected:
+      entities: ["cell_type", "disease", "human gene", "drug", "mouse gene", "go term"]
+      relationships: ["gene to disease association", "gene to go term association"]
+      relationship_labels:
+        gene_to_disease_association:
+          source: human gene
+          target: disease
+        gene_to_go_term_association:
+          source: human gene
+          target: go term
+      properties:
+        disease: ["code", "name", "description", "ontology"]
+        cell_type: ["name"]
+        human_gene: ["approvedSymbol", "approvedName", "biotype"]
+        mouse_gene: ["targetInModel", "targetInModelMgiId", "targetFromSourceId"]
+        drug: ["name", "description"]
+        go_term: ["name"]
+        gene_to_disease_association: ["literature", "score"]
+        gene_to_go_term_association: ["literature"]
+      parts_of_query:
+        [
+          "^MATCH",                             # Basic Cypher match clause
+          "DISTINCT",                           # Using DISTINCT to avoid duplicate results
+          "([a-zA-Z]*:human_gene)",             # Human gene label
+          "([a-zA-Z]*:disease)",                # Disease label
+          "([a-zA-Z]*:cell_type)",              # Cell type label
+          "NASH",                               # Disease name condition for 'NASH'
+          "\\(.*:human_gene\\)-\\[:gene_to_disease_association\\]-\\(.*:disease\\)",  # Association between human gene and disease
+          "\\(.*:human_gene\\)-\\[:gene_to_go_term_association\\]-\\(.*:go_term\\)",  # Association between human gene and GO term
+          "RETURN\\s+(DISTINCT\\s+)?cell_type\\.name",  # Return clause for cell_type names
+        ]
+
+    # test ability to answer question about drugs for a disease in gene_kg
+  - case: DRUG_GENE_KG1
+    input:
+      kg_schema: gene_kg
+      prompt: Are there already drugs for my disease of interest?
+      language: Cypher
+    expected:
+      entities: ["Disease", "Protein", "Gene"]
+      relationships: ["GENE_TO_DISEASE_ASSOCIATION", "GENE_TO_PROTEIN_ASSOCIATION"]
+      relationship_labels:
+        GENE_TO_DISEASE_ASSOCIATION:
+          source: Gene
+          target: Disease
+        GENE_TO_PROTEIN_ASSOCIATION:
+          source: Gene
+          target: Protein
+      properties:
+        Disease: ["name", "ICD10", "DSM5"]
+        Gene: ["id", "name", "taxon"]
+        Protein: ["name", "genes", "score", "taxon"]
+        GENE_TO_DISEASE_ASSOCIATION: ["evidence", "score", "source"]
+        GENE_TO_PROTEIN_ASSOCIATION: ["evidence", "score", "source"]
+      parts_of_query:
+        [
+          "^MATCH",
+          "([a-zA-Z]*:Disease)",
+          "([a-zA-Z]*:Gene)",
+          "([a-zA-Z]*:Protein)",
+          "\\(.*?\\)-\\[:GENE_TO_DISEASE_ASSOCIATION\\]->\\(.*?\\)",
+          "\\(.*?\\)-\\[:GENE_TO_PROTEIN_ASSOCIATION\\]->\\(.*?\\)",
+          "RETURN\\s+(DISTINCT\\s+)?Gene\\.name",
+        ]
+
+      # test ability to answer question about drugs for a disease in safety_kg
+  - case: DRUG_SAFETY_KG1
+    input:
+      kg_schema: safety_kg
+      prompt: Are there already drugs for my disease of interest?
+      language: Cypher
+    expected:
+      entities: ["CaseStudy", "Chemical", "Bioassay", "Organ"]
+      relationships: ["CASE_STUDY_RELEVANT_CHEMICAL", "CHEMICAL_MEASURED_WITH_BIOASSAY", "BIOASSAY_EXECUTED_ON_MODEL_SYSTEM"]
+      relationship_labels:
+        CASE_STUDY_RELEVANT_CHEMICAL:
+          source: CaseStudy
+          target: Chemical
+        CHEMICAL_MEASURED_WITH_BIOASSAY:
+          source: Chemical
+          target: Bioassay
+        BIOASSAY_EXECUTED_ON_MODEL_SYSTEM:
+          source: Bioassay
+          target: ModelSystem
+      properties:
+        CaseStudy: ["name", "description"]
+        Chemical: ["name", "CAS", "SMILES", "InChIKey"]
+        Bioassay: ["name", "measured"]
+        Organ: ["name"]
+        CASE_STUDY_RELEVANT_CHEMICAL: []
+        CHEMICAL_MEASURED_WITH_BIOASSAY: []
+        BIOASSAY_EXECUTED_ON_MODEL_SYSTEM: []
+      parts_of_query:
+        [
+          "^MATCH",
+          "([a-zA-Z]*:CaseStudy)",
+          "([a-zA-Z]*:Chemical)",
+          "([a-zA-Z]*:Bioassay)",
+          "([a-zA-Z]*:ModelSystem)",
+          "\\(.*?\\)-\\[:CASE_STUDY_RELEVANT_CHEMICAL\\]->\\(.*?\\)",
+          "\\(.*?\\)-\\[:CHEMICAL_MEASURED_WITH_BIOASSAY\\]->\\(.*?\\)",
+          "\\(.*?\\)-\\[:BIOASSAY_EXECUTED_ON_MODEL_SYSTEM\\]->\\(.*?\\)",
+          "RETURN\\s+(DISTINCT\\s+)?Chemical\\.name",
+        ]
+
+    # test ability to answer question about available drugs for a disease
+  - case: DRUG1
+    input:
+      kg_schema: hetionet
+      prompt: Are there already drugs for my disease of interest?
+      language: Cypher
+    expected:
+      entities: ["Disease", "Compound"]
+      relationships: ["COMPOUND_DISEASE_TREATMENT"]
+      relationship_labels:
+        COMPOUND_DISEASE_TREATMENT:
+          source: Compound
+          target: Disease
+      properties:
+        Disease: ["name", "mesh_id", "umls_id"]
+        Compound: ["name", "smiles", "inchi"]
+        COMPOUND_DISEASE_TREATMENT: ["phase", "source"]
+      parts_of_query:
+        [
+          "^MATCH",
+          "([a-zA-Z]*:Disease)",
+          "([a-zA-Z]*:Compound)",
+          "\\(.*?\\)-\\[:COMPOUND_DISEASE_TREATMENT\\]->\\(.*?\\)",
+          "RETURN\\s+(DISTINCT\\s+)?Compound\\.name",
+        ]
+        
+  # test ability to answer question about drugs for a disease in open-targets
+  - case: DRUG_OPEN_TARGETS1
+    input:
+      kg_schema: open-targets
+      prompt: Are there already drugs for my disease of interest?
+      language: Cypher
+    expected:
+      entities: ["Disease", "Drug"]
+      relationships: ["GENE_TO_DISEASE_ASSOCIATION"]
+      relationship_labels:
+        GENE_TO_DISEASE_ASSOCIATION:
+          source: Gene
+          target: Disease
+      properties:
+        Disease: ["code", "name", "description", "ontology"]
+        Drug: ["name", "description"]
+        GENE_TO_DISEASE_ASSOCIATION: ["score", "literature"]
+      parts_of_query:
+        [
+          "^MATCH",
+          "([a-zA-Z]*:Disease)",
+          "([a-zA-Z]*:Drug)",
+          "\\(.*?\\)-\\[:GENE_TO_DISEASE_ASSOCIATION\\]->\\(.*?\\)",
+          "RETURN\\s+(DISTINCT\\s+)?Drug\\.name",
+        ]
+
+
+
   # test cypher query with single-word entities
   - case: single_word
     input:
       kg_schema: gene_kg
       prompt: Which genes are associated with mucoviscidosis?
+      language: Cypher
     expected:
       entities: ["Gene", "Disease"]
       relationships: ["GeneToPhenotypeAssociation"]
@@ -62,6 +390,7 @@ biocypher_query_generation:
     input:
       kg_schema: gene_kg
       prompt: Which genes are expressed in fibroblasts?
+      language: Cypher
     expected:
       entities: ["Gene", "CellType"]
       relationships: ["GeneExpressedInCellType"]
@@ -90,6 +419,7 @@ biocypher_query_generation:
     input:
       kg_schema: gene_kg
       prompt: Which proteins are associated with the disease having ICD10 code 'E10', what are their scores, and what is the gene related to these proteins?
+      language: Cypher
     expected:
       entities: ["Protein", "Disease", "Gene"]
       relationships: ["GeneToPhenotypeAssociation", "GeneToProteinAssociation"]
@@ -124,6 +454,7 @@ biocypher_query_generation:
     input:
       kg_schema: safety_kg
       prompt: Which organs are in our dataset?
+      language: Cypher
     expected:
       entities: ["Organ"]
       relationships: []
@@ -136,6 +467,7 @@ biocypher_query_generation:
     input:
       kg_schema: safety_kg
       prompt: Which model systems are used in the brain?
+      language: Cypher
     expected:
       entities: ["ModelSystem", "Organ"]
       relationships: ["ModelSystemRelevantToOrgan"]
@@ -162,6 +494,7 @@ biocypher_query_generation:
     input:
       kg_schema: safety_kg
       prompt: Which case studies are performed on the brain, and which chemicals are used in these case studies?
+      language: Cypher
     expected:
       entities: ["CaseStudy", "Organ", "Chemical"]
       relationships: ["CaseStudyRelatedOrgan", "CaseStudyRelevantChemical"]

--- a/benchmark/test_biocypher_query_generation.py
+++ b/benchmark/test_biocypher_query_generation.py
@@ -1,17 +1,16 @@
-import inspect
-import json
 import re
+import json
+import inspect
 
 import pytest
 
 from biochatter.prompts import BioCypherPromptEngine
-
+from .conftest import calculate_bool_vector_score
 from .benchmark_utils import (
-    get_result_file_path,
     skip_if_already_run,
+    get_result_file_path,
     write_results_to_file,
 )
-from .conftest import calculate_bool_vector_score
 
 
 def test_naive_query_generation_using_schema(
@@ -24,9 +23,7 @@ def test_naive_query_generation_using_schema(
     yaml_data = test_data_biocypher_query_generation
     task = f"{inspect.currentframe().f_code.co_name.replace('test_', '')}"
     skip_if_already_run(
-        model_name=model_name,
-        task=task,
-        md5_hash=yaml_data["hash"],
+        model_name=model_name, task=task, md5_hash=yaml_data["hash"]
     )
     schema = kg_schemas[yaml_data["input"]["kg_schema"]]
 
@@ -36,11 +33,11 @@ def test_naive_query_generation_using_schema(
         conversation.append_system_message(
             "You are a database expert. Please write a Cypher query to "
             "retrieve information for the user. The schema of the graph is "
-            "defined as follows: ",
+            "defined as follows: "
         )
         conversation.append_system_message(json.dumps(schema, indent=2))
         conversation.append_system_message(
-            "Only return the query, nothing else.",
+            "Only return the query, nothing else."
         )
 
         query, _, _ = conversation.query(yaml_data["input"]["prompt"])
@@ -49,11 +46,12 @@ def test_naive_query_generation_using_schema(
         for expected_part_of_query in yaml_data["expected"]["parts_of_query"]:
             if isinstance(expected_part_of_query, tuple):
                 score.append(
-                    expected_part_of_query[0] in query or expected_part_of_query[1] in query,
+                    expected_part_of_query[0] in query
+                    or expected_part_of_query[1] in query
                 )
             else:
                 score.append(
-                    re.search(expected_part_of_query, query) is not None,
+                    (re.search(expected_part_of_query, query) is not None)
                 )
         return calculate_bool_vector_score(score)
 
@@ -76,14 +74,11 @@ def get_prompt_engine(
     """Helper function to create the prompt engine for the test.
 
     Args:
-    ----
         kg_schema_dict (dict): The KG schema
         create_prompt_engine: The function to create the BioCypherPromptEngine
 
     Returns:
-    -------
         BioCypherPromptEngine: The prompt engine for the test
-
     """
     return create_prompt_engine(kg_schema_dict=kg_schema_dict)
 
@@ -99,13 +94,10 @@ def test_entity_selection(
     yaml_data = test_data_biocypher_query_generation
     task = f"{inspect.currentframe().f_code.co_name.replace('test_', '')}"
     skip_if_already_run(
-        model_name=model_name,
-        task=task,
-        md5_hash=yaml_data["hash"],
+        model_name=model_name, task=task, md5_hash=yaml_data["hash"]
     )
     prompt_engine = get_prompt_engine(
-        kg_schemas[yaml_data["input"]["kg_schema"]],
-        prompt_engine,
+        kg_schemas[yaml_data["input"]["kg_schema"]], prompt_engine
     )
 
     def run_test():
@@ -146,13 +138,10 @@ def test_relationship_selection(
     if not yaml_data["expected"]["relationships"]:
         pytest.skip("No relationships to test")
     skip_if_already_run(
-        model_name=model_name,
-        task=task,
-        md5_hash=yaml_data["hash"],
+        model_name=model_name, task=task, md5_hash=yaml_data["hash"]
     )
     prompt_engine = get_prompt_engine(
-        kg_schemas[yaml_data["input"]["kg_schema"]],
-        prompt_engine,
+        kg_schemas[yaml_data["input"]["kg_schema"]], prompt_engine
     )
 
     prompt_engine.question = yaml_data["input"]["prompt"]
@@ -166,18 +155,23 @@ def test_relationship_selection(
         assert success
 
         score = []
-        for expected_relationship_label_key in yaml_data["expected"]["relationship_labels"].keys():
+        for expected_relationship_label_key in yaml_data["expected"][
+            "relationship_labels"
+        ].keys():
             score.append(
-                expected_relationship_label_key in prompt_engine.selected_relationship_labels.keys(),
+                expected_relationship_label_key
+                in prompt_engine.selected_relationship_labels.keys()
             )
 
-            for expected_relationship_label_value in yaml_data["expected"]["relationship_labels"][
-                expected_relationship_label_key
-            ]:
+            for expected_relationship_label_value in yaml_data["expected"][
+                "relationship_labels"
+            ][expected_relationship_label_key]:
                 try:
                     score.append(
                         expected_relationship_label_value
-                        in prompt_engine.selected_relationship_labels[expected_relationship_label_key],
+                        in prompt_engine.selected_relationship_labels[
+                            expected_relationship_label_key
+                        ]
                     )
                 except KeyError:
                     score.append(False)
@@ -206,18 +200,17 @@ def test_property_selection(
     yaml_data = test_data_biocypher_query_generation
     task = f"{inspect.currentframe().f_code.co_name.replace('test_', '')}"
     skip_if_already_run(
-        model_name=model_name,
-        task=task,
-        md5_hash=yaml_data["hash"],
+        model_name=model_name, task=task, md5_hash=yaml_data["hash"]
     )
     prompt_engine = get_prompt_engine(
-        kg_schemas[yaml_data["input"]["kg_schema"]],
-        prompt_engine,
+        kg_schemas[yaml_data["input"]["kg_schema"]], prompt_engine
     )
 
     prompt_engine.question = yaml_data["input"]["prompt"]
     prompt_engine.selected_entities = yaml_data["expected"]["entities"]
-    prompt_engine.selected_relationships = yaml_data["expected"]["relationships"]
+    prompt_engine.selected_relationships = yaml_data["expected"][
+        "relationships"
+    ]
 
     def run_test():
         conversation.reset()  # needs to be reset for each test
@@ -225,25 +218,35 @@ def test_property_selection(
 
         if success:
             score = []
-            for expected_property_key in yaml_data["expected"]["properties"].keys():
+            for expected_property_key in yaml_data["expected"][
+                "properties"
+            ].keys():
                 try:
                     score.append(
-                        expected_property_key in prompt_engine.selected_properties.keys(),
+                        expected_property_key
+                        in prompt_engine.selected_properties.keys()
                     )
                 except KeyError:
                     score.append(False)
 
-                for expected_property_value in yaml_data["expected"]["properties"][expected_property_key]:
+                for expected_property_value in yaml_data["expected"][
+                    "properties"
+                ][expected_property_key]:
                     try:
                         score.append(
-                            expected_property_value in prompt_engine.selected_properties[expected_property_key],
+                            expected_property_value
+                            in prompt_engine.selected_properties[
+                                expected_property_key
+                            ]
                         )
                     except KeyError:
                         score.append(False)
         else:
             total_properties = len(
-                yaml_data["expected"]["properties"].keys(),
-            ) + sum(len(v) for v in yaml_data["expected"]["properties"].values())
+                yaml_data["expected"]["properties"].keys()
+            ) + sum(
+                len(v) for v in yaml_data["expected"]["properties"].values()
+            )
             score = [False] * total_properties
 
         return calculate_bool_vector_score(score)
@@ -271,13 +274,10 @@ def test_query_generation(
     yaml_data = test_data_biocypher_query_generation
     task = f"{inspect.currentframe().f_code.co_name.replace('test_', '')}"
     skip_if_already_run(
-        model_name=model_name,
-        task=task,
-        md5_hash=yaml_data["hash"],
+        model_name=model_name, task=task, md5_hash=yaml_data["hash"]
     )
     prompt_engine = get_prompt_engine(
-        kg_schemas[yaml_data["input"]["kg_schema"]],
-        prompt_engine,
+        kg_schemas[yaml_data["input"]["kg_schema"]], prompt_engine
     )
 
     def run_test():
@@ -287,7 +287,7 @@ def test_query_generation(
             entities=yaml_data["expected"]["entities"],
             relationships=yaml_data["expected"]["relationship_labels"],
             properties=yaml_data["expected"]["properties"],
-            query_language="Cypher",
+            query_language=yaml_data["input"]["language"],
             conversation=conversation,
         )
 
@@ -295,11 +295,12 @@ def test_query_generation(
         for expected_part_of_query in yaml_data["expected"]["parts_of_query"]:
             if isinstance(expected_part_of_query, tuple):
                 score.append(
-                    expected_part_of_query[0] in query or expected_part_of_query[1] in query,
+                    expected_part_of_query[0] in query
+                    or expected_part_of_query[1] in query
                 )
             else:
                 score.append(
-                    re.search(expected_part_of_query, query) is not None,
+                    (re.search(expected_part_of_query, query) is not None)
                 )
         return calculate_bool_vector_score(score)
 
@@ -326,13 +327,10 @@ def test_end_to_end_query_generation(
     yaml_data = test_data_biocypher_query_generation
     task = f"{inspect.currentframe().f_code.co_name.replace('test_', '')}"
     skip_if_already_run(
-        model_name=model_name,
-        task=task,
-        md5_hash=yaml_data["hash"],
+        model_name=model_name, task=task, md5_hash=yaml_data["hash"]
     )
     prompt_engine = get_prompt_engine(
-        kg_schemas[yaml_data["input"]["kg_schema"]],
-        prompt_engine,
+        kg_schemas[yaml_data["input"]["kg_schema"]], prompt_engine
     )
 
     def run_test():
@@ -343,16 +341,19 @@ def test_end_to_end_query_generation(
                 query_language="Cypher",
             )
             score = []
-            for expected_part_of_query in yaml_data["expected"]["parts_of_query"]:
+            for expected_part_of_query in yaml_data["expected"][
+                "parts_of_query"
+            ]:
                 if isinstance(expected_part_of_query, tuple):
                     score.append(
-                        expected_part_of_query[0] in query or expected_part_of_query[1] in query,
+                        expected_part_of_query[0] in query
+                        or expected_part_of_query[1] in query
                     )
                 else:
                     score.append(
-                        re.search(expected_part_of_query, query) is not None,
+                        (re.search(expected_part_of_query, query) is not None)
                     )
-        except ValueError:
+        except ValueError as e:
             score = [False for _ in yaml_data["expected"]["parts_of_query"]]
 
         return calculate_bool_vector_score(score)
@@ -463,13 +464,10 @@ def test_property_exists(
     yaml_data = test_data_biocypher_query_generation
     task = f"{inspect.currentframe().f_code.co_name.replace('test_', '')}"
     skip_if_already_run(
-        model_name=model_name,
-        task=task,
-        md5_hash=yaml_data["hash"],
+        model_name=model_name, task=task, md5_hash=yaml_data["hash"]
     )
     prompt_engine = get_prompt_engine(
-        kg_schemas[yaml_data["input"]["kg_schema"]],
-        prompt_engine,
+        kg_schemas[yaml_data["input"]["kg_schema"]], prompt_engine
     )
 
     def run_test():
@@ -492,16 +490,22 @@ def test_property_exists(
         ) = get_used_property_from_query(query)
 
         for entity, property in used_entity_property.items():
-            if entity in prompt_engine.entities.keys() and "properties" in prompt_engine.entities[entity]:
+            if (
+                entity in prompt_engine.entities.keys()
+                and "properties" in prompt_engine.entities[entity]
+            ):
                 # check property used is in available properties for entities
                 avail_property_entity = list(
-                    prompt_engine.entities[entity]["properties"].keys(),
+                    prompt_engine.entities[entity]["properties"].keys()
                 )
                 score.append(property in avail_property_entity)
-            elif entity in prompt_engine.relationships.keys() and "properties" in prompt_engine.relationships[entity]:
+            elif (
+                entity in prompt_engine.relationships.keys()
+                and "properties" in prompt_engine.relationships[entity]
+            ):
                 # check property used is in available properties for relationships
                 avail_property_entity = list(
-                    prompt_engine.relationships[entity]["properties"].keys(),
+                    prompt_engine.relationships[entity]["properties"].keys()
                 )
                 score.append(property in avail_property_entity)
             else:
@@ -533,9 +537,10 @@ def test_regex(test_data_biocypher_query_generation):
     for expected_part_of_query in yaml_data["expected"]["parts_of_query"]:
         if isinstance(expected_part_of_query, tuple):
             score.append(
-                expected_part_of_query[0] in query or expected_part_of_query[1] in query,
+                expected_part_of_query[0] in query
+                or expected_part_of_query[1] in query
             )
         else:
-            score.append(re.search(expected_part_of_query, query) is not None)
+            score.append((re.search(expected_part_of_query, query) is not None))
 
         assert True


### PR DESCRIPTION
1. added additional benchmarking cases related to OTAR business questions
- added benchmarking cases for SQL in addition to existing Cypher benchmarks
2. added two additional KG schemas:
- 'hetionet' based on hetionet drug repurposing KG
- 'open-targets' based on open-targets KG
