### PR TITLE
remove non-number values from stats return

### DIFF
--- a/biochatter/llm_connect.py
+++ b/biochatter/llm_connect.py
@@ -1595,9 +1595,15 @@ class GptConversation(Conversation):
 
         """
         if self.user == "community":
+            # Only process integer values
+            stats_dict = {
+                f"{k}:{model}": v
+                for k, v in token_usage.items()
+                if isinstance(v, int | float)
+            }
             self.usage_stats.increment(
                 "usage:[date]:[user]",
-                {f"{k}:{model}": v for k, v in token_usage.items()},
+                stats_dict,
             )
 
         if self._update_token_usage is not None:

--- a/test/test_llm_connect.py
+++ b/test/test_llm_connect.py
@@ -684,3 +684,57 @@ def test_chat_attributes_set_on_success(mock_openai):
     # Verify both chat attributes are accessible
     assert convo.chat is not None
     assert convo.ca_chat is not None
+
+
+def test_gpt_update_usage_stats():
+    """Test the _update_usage_stats method in GptConversation."""
+    # Arrange
+    convo = GptConversation(
+        model_name="gpt-3.5-turbo",
+        prompts={},
+        correct=False,
+    )
+ 
+    # Mock the usage_stats object
+    mock_usage_stats = Mock()
+    convo.usage_stats = mock_usage_stats
+    convo.user = "community"  # Set user to enable stats tracking
+
+    # Mock the update_token_usage callback
+    mock_update_callback = Mock()
+    convo._update_token_usage = mock_update_callback
+
+    model = "gpt-3.5-turbo"
+    token_usage = {
+        "prompt_tokens": 50,
+        "completion_tokens": 30,
+        "total_tokens": 80,
+        "non_numeric_field": "should be ignored",
+        "nested_dict": {  # Should be ignored as it's a dictionary
+            "sub_field": 100,
+            "another_field": 200,
+        },
+        "another_field": "also ignored",
+    }
+
+    # Act
+    convo._update_usage_stats(model, token_usage)
+
+    # Assert
+    # Verify increment was called with correct arguments for community stats
+    # Only numeric values at the top level should be included
+    mock_usage_stats.increment.assert_called_once_with(
+        "usage:[date]:[user]",
+        {
+            "prompt_tokens:gpt-3.5-turbo": 50,
+            "completion_tokens:gpt-3.5-turbo": 30,
+            "total_tokens:gpt-3.5-turbo": 80,
+        },
+    )
+
+    # Verify callback was called with complete token_usage including nested dict
+    mock_update_callback.assert_called_once_with(
+        "community",
+        "gpt-3.5-turbo",
+        token_usage,  # Full dictionary including nested values
+    )


### PR DESCRIPTION
This PR introduces a change to stats processing to fix a bug in the biochatter light application. OpenAI have added dictionaries for their advanced usages which carry further tokens but were not accounted for in the original implementation. We now ignore them, will revisit later to see if they're important for our community key usage (but probably not, since we only demo very basic things for now).

Also introduces a test for the new setup. Bump patch.