### PR TITLE
Fixed minor typo in the rag.md doc file

### DIFF
--- a/docs/features/rag.md
+++ b/docs/features/rag.md
@@ -159,7 +159,7 @@ a database language.
 ```python
 query = prompt_engine.generate_query(
     question="Which genes are associated with mucoviscidosis?",
-    database_language="Cypher",
+    query_language="Cypher",
 )
 ```
 


### PR DESCRIPTION
# Description

Proposing fix for a minor typo in the RAG feature documentation.

In the example the query language (i.e.: "Cypher") is passed to the `generate_query` through the `database_language`. However, current implementation passes query language to LLM through the `query_language` argument.

# Solution

Correct the rag.md file