### PR TITLE
Improve prompt structure and reduce hallucination risk in web API agents

### DIFF
--- a/biochatter/api_agent/web/bio_tools.py
+++ b/biochatter/api_agent/web/bio_tools.py
@@ -20,7 +20,7 @@ from biochatter.api_agent.base.agent_abc import (
 )
 
 BIOTOOLS_QUERY_PROMPT = """
-You are a world class algorithm for creating queries in structured formats. Your task is to use the web API of bio.tools
+You are a system designed to create structured queries for the bio.tools web API. Your task is to use the web API of bio.tools
 to answer questions about bioinformatics tools and their properties.
 
 You have to extract the appropriate information out of the examples:
@@ -245,12 +245,13 @@ https://bio.tools/api/tool?biotoolsID=blast returns all tools with “blast” i
 
 
 BIOTOOLS_SUMMARY_PROMPT = """
-You have to answer this question in a clear and concise manner: {question} Be factual!\n\
-You are a world leading bioinformatician who knows everything about bio.tools packages.\n\
-Do not make up information, only use the provided information and mention how relevant the found information is based on
-your knowledge about bio.tools.\n\
-Here is the information relevant to the question found on the bio.tools web API:\n\
+Based on the following information from the bio.tools web API:
+
 {context}
+
+Answer this question clearly and concisely: {question}
+
+Be factual and only use the provided information. If the information is incomplete or doesn't fully answer the question, mention this limitation.
 """
 
 
@@ -644,11 +645,11 @@ class BioToolsInterpreter(BaseInterpreter):
             [
                 (
                     "system",
-                    "You are a world class bioinformatician who knows "
-                    "everything about bio.tools packages and the "
-                    "bioinformatics ecosystem. Your task is to interpret "
-                    "results from BioTools API calls and summarise "
-                    "them for the user.",
+                    "You are an experienced bioinformatician specializing in "
+                    "bio.tools packages and the bioinformatics ecosystem. "
+                    "Your task is to interpret results from BioTools API calls "
+                    "and summarise them for the user. Focus on the provided data and "
+                    "be clear about any limitations in the information.",
                 ),
                 ("user", "{input}"),
             ],

--- a/biochatter/api_agent/web/blast.py
+++ b/biochatter/api_agent/web/blast.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 from ..base.agent_abc import BaseFetcher, BaseInterpreter, BaseQueryBuilder
 
 BLAST_QUERY_PROMPT = """
-You are a world class algorithm for creating queries in structured formats. Your task is to use NCBI Web APIs to answer
+You are a system designed to create structured queries for NCBI BLAST APIs. Your task is to use NCBI Web APIs to answer
 genomic questions.
 
 For questions about DNA sequences (other than genome alignments) you can use BLAST by: "[https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi?CMD={Put|Get}&PROGRAM=blastn&MEGABLAST=on&DATABASE=nt&FORMAT_TYPE={XML|Text}&QUERY={sequence}&HITLIST_SIZE={max_hit_size}]".
@@ -40,16 +40,19 @@ Use BLASTp for such a question -> https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=P
 """  # noqa: E501
 
 BLAST_SUMMARY_PROMPT = """
-You have to answer this question in a clear and concise manner: {question} Be factual!\n\
-If you are asked what organism a specific sequence belongs to, check the 'Hit_def' fields. If you find a synthetic
-construct or predicted entry, move to the next one and look for an organism name.\n\
-Try to use the hits with the best identity score to answer the question. If it is not possible, move to the next one.\n\
-Be clear, and if organism names are present in ANY of the results, please include them in the answer. Do not make up
-information and mention how relevant the found information is based on the identity scores.\n\
-Use the same reasoning for any potential BLAST results. If you find information that is manually curated, please use it
-and state it. You may also state other results, but always include the context.\n\
-Based on the information given here:\n\
+Based on the following BLAST results:
+
 {context}
+
+Answer this question clearly and concisely: {question}
+
+Analysis guidelines:
+- For organism identification, check 'Hit_def' fields, if you find a syntethic construct or predicted entry, move the the next one and look for an organism name.
+- Use hits with the best identity scores when possible, if it is not possible, move to the next one.
+- Always include organism names when present in the results
+- Mention the quality and relevance of matches based on identity scores
+- If information is manually curated, prioritize it and indicate this
+- Be factual and only use the provided information
 """
 
 
@@ -355,7 +358,11 @@ class BlastInterpreter(BaseInterpreter):
             [
                 (
                     "system",
-                    "You are a world class molecular biologist who knows everything about NCBI and BLAST results.",
+                    "You are an experienced molecular biologist specializing in "
+                    "sequence analysis and BLAST results interpretation. Your task "
+                    "is to analyze BLAST output and provide clear, accurate summaries "
+                    "based on the provided data. Focus on the provided data and "
+                    "be clear about any limitations in the information.",
                 ),
                 ("user", "{input}"),
             ],

--- a/biochatter/api_agent/web/oncokb.py
+++ b/biochatter/api_agent/web/oncokb.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 ONCOKB_QUERY_PROMPT = """
-You are a world class algorithm for creating queries in structured formats. Your task is to use OncoKB Web APIs to
+You are a system designed to create structured queries for the OncoKB web API. Your task is to use OncoKB Web APIs to
 answer genomic questions.
 
 For questions about genomic alterations, you can use the OncoKB API by providing the appropriate parameters based on the
@@ -111,11 +111,13 @@ Endpoints and Parameters
 
 
 ONCOKB_SUMMARY_PROMPT = """
-You have to answer this question in a clear and concise manner: {question} Be factual!\n\
-You are a world leading oncologist and molecular biologist who knows everything about OncoKB results.\n\
-Do not make up information, only use the provided information and mention how relevant the found information is based on your knowledge about OncoKB\n\
-Here is the information relevant to the question found on OncoKB:\n\
+Based on the following information from OncoKB:
+
 {context}
+
+Answer this question clearly and concisely: {question}
+
+Be factual and only use the provided information. If the information is incomplete or doesn't fully answer the question, mention this limitation.
 """
 
 
@@ -343,10 +345,11 @@ class OncoKBInterpreter(BaseInterpreter):
             [
                 (
                     "system",
-                    "You are a world class molecular biologist who knows "
-                    "everything about OncoKB and cancer genomics. Your task is "
-                    "to interpret results from OncoKB API calls and summarise "
-                    "them for the user.",
+                    "You are an experienced oncologist and molecular biologist "
+                    "specializing in cancer genomics and OncoKB data interpretation. "
+                    "Your task is to interpret results from OncoKB API calls and "
+                    "summarise them for the user. Focus on the provided data and "
+                    "be clear about any limitations in the information.",
                 ),
                 ("user", "{input}"),
             ],


### PR DESCRIPTION
In this PR we address some improvements to the prompt templates in the web API agents (BLAST, OncoKB and bio.tools) that should help to improve the response quality of the agent.

Summary of the changes:

- Moved context before questions in all summary prompts, this way we reduce the risk of prioritizing the question and skimming the context based on that. Also, model gets all the background info first, then receives the question which follows the best practices in writing prompt templates.
- Moved all the system prompts to the ChatPromptTemplate instead of mixing them in the user prompts.
- Replaced "world class", "knows everything" language with "experienced" and "specializing in" or in query prompts used "system designed to" instead of "world class algorithm".

These changes should reduce hallucination risks and encourage the model to more evidence-based responses.