### PR TITLE
fix: remove return of token usage for the correcting agent for BioChatter light

### DIFF
--- a/biochatter/llm_connect/langchain.py
+++ b/biochatter/llm_connect/langchain.py
@@ -270,7 +270,7 @@ class LangChainConversation(Conversation):
         response = self.ca_chat.invoke(ca_messages)
 
         correction = response.content
-        token_usage_raw = response.usage_metadata
-        token_usage = self._extract_total_tokens(token_usage_raw)
+        # token_usage_raw = response.usage_metadata
+        # token_usage = self._extract_total_tokens(token_usage_raw)
 
-        return correction, token_usage
+        return correction


### PR DESCRIPTION
Erroneously, https://github.com/biocypher/biochatter/pull/304 introduced a return of the token usage for the correcting agent, breaking compatibility with the BioChatter-light interface. This PR addresses the issue by reverting to the original behavior.