### PR TITLE
Update selector_agent.py: prevent LangChainDeprecationWarning from being issued

### DIFF
--- a/biochatter/kg_langgraph_agent.py
+++ b/biochatter/kg_langgraph_agent.py
@@ -10,7 +10,7 @@ from langchain.output_parsers.openai_tools import (
 )
 from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END
 

--- a/biochatter/langgraph_agent_base.py
+++ b/biochatter/langgraph_agent_base.py
@@ -11,7 +11,7 @@ from langchain_core.messages import (
     HumanMessage,
     ToolMessage,
 )
-from langchain_core.pydantic_v1 import ValidationError
+from pydantic import ValidationError
 from langgraph.graph import END, MessageGraph
 from langgraph.graph.graph import CompiledGraph
 from langsmith import traceable

--- a/biochatter/selector_agent.py
+++ b/biochatter/selector_agent.py
@@ -8,7 +8,7 @@ from langchain.output_parsers.openai_tools import (
 )
 from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END
 


### PR DESCRIPTION
Prevent the following "LangChainDeprecationWarning" from being issued:
```
[~]/biochatter/biochatter/llm_connect/conversation.py:34: LangChainDeprecationWarning: As of langchain-core 0.3.0, LangChain uses pydantic v2 internally. The langchain_core.pydantic_v1 module was a compatibility shim for pydantic v1, and should no longer be used. Please update the code to import from Pydantic directly.

For example, replace imports like: `from langchain_core.pydantic_v1 import BaseModel` with: `from pydantic import BaseModel`
or the v1 compatibility namespace if you are working in a code base that has not been fully upgraded to pydantic 2 yet.         from pydantic.v1 import BaseModel

  from biochatter.selector_agent import RagAgentSelector
```